### PR TITLE
feat: 친구 요청 수락/거절 기능 구현, 친구 목록 서버에서 받도록 변경

### DIFF
--- a/app/(tabs)/friend.tsx
+++ b/app/(tabs)/friend.tsx
@@ -5,8 +5,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { FriendItem, FriendRequest } from "@/components/FriendItem";
 import FriendTab from "@/components/FriendTab";
 import SearchBar from "@/components/SearchBar";
-import { USERS } from "@/mockData/user";
-import { getFriendRequests } from "@/utils/supabase";
+import { getFriendRequests, getFriends } from "@/utils/supabase";
 
 /* 실제 컴포넌트 */
 
@@ -17,6 +16,13 @@ export default function Friend() {
   const [isFriendTab, setIsFriendTab] = useState(true);
   const [keyword, setKeyword] = useState("");
 
+  const [friends, setFriends] = useState<
+    Awaited<ReturnType<typeof getFriends>>
+  >({
+    data: [],
+    total: 0,
+    hasMore: false,
+  });
   const [requests, setRequests] = useState<
     Awaited<ReturnType<typeof getFriendRequests>>
   >({
@@ -25,17 +31,26 @@ export default function Friend() {
     hasMore: false,
   });
 
-  const fetchRequests = useCallback(async () => {
-    const fetchedRequest = await getFriendRequests({
+  const fetchFriends = useCallback(async () => {
+    const fetchedFriends = await getFriends({
       offset: OFFSET,
       limit: LIMIT,
     });
-    setRequests(fetchedRequest);
+    setFriends(fetchedFriends);
+  }, []);
+
+  const fetchRequests = useCallback(async () => {
+    const fetchedRequests = await getFriendRequests({
+      offset: OFFSET,
+      limit: LIMIT,
+    });
+    setRequests(fetchedRequests);
   }, []);
 
   useEffect(() => {
+    fetchFriends();
     fetchRequests();
-  }, [fetchRequests]);
+  }, [fetchFriends, fetchRequests]);
 
   return (
     <SafeAreaView edges={[]} className="flex-1 bg-white">
@@ -56,11 +71,9 @@ export default function Friend() {
           />
 
           <View className="px-2 pt-2">
-            {[1, 2, 3, 4, 5].map((n) =>
-              USERS.map((user) => (
-                <FriendItem key={n + user.id} fromUser={user} />
-              )),
-            )}
+            {friends.data.map((friend) => (
+              <FriendItem key={friend.id} fromUser={friend} />
+            ))}
           </View>
 
           <View className="h-4" />

--- a/app/(tabs)/friend.tsx
+++ b/app/(tabs)/friend.tsx
@@ -58,7 +58,7 @@ export default function Friend() {
           <View className="px-2 pt-2">
             {[1, 2, 3, 4, 5].map((n) =>
               USERS.map((user) => (
-                <FriendItem key={n + user.accountId} {...user} />
+                <FriendItem key={n + user.id} fromUser={user} />
               )),
             )}
           </View>
@@ -69,8 +69,8 @@ export default function Friend() {
         <ScrollView className="px-8 grow w-full">
           {/* 상단에 패딩을 주면 일부 모바일에서 패딩만큼 끝이 잘려보여서 높이 조절을 위해 추가 */}
           <View className="h-2" />
-          {requests.data.map(({ id, from }) => (
-            <FriendRequest key={id} {...from} />
+          {requests.data.map((request) => (
+            <FriendRequest key={request.requestId} {...request} />
           ))}
           <View className="h-4" />
         </ScrollView>

--- a/mockData/user.ts
+++ b/mockData/user.ts
@@ -1,5 +1,6 @@
 export interface User {
-  accountId: string;
+  id: string;
+  email: string;
   username: string;
   avatarUrl: string;
   description: string;
@@ -8,7 +9,8 @@ export interface User {
 
 export const USERS: User[] = [
   {
-    accountId: "1",
+    id: "1",
+    email: "",
     username: "개발자",
     avatarUrl:
       "https://zrkselfyyqkkqcmxhjlt.supabase.co/storage/v1/object/public/images/1730962073092-thumbnail.webp",
@@ -16,14 +18,16 @@ export const USERS: User[] = [
     status: "DONE",
   },
   {
-    accountId: "2",
+    id: "2",
+    email: "",
     username: "개발자2",
     avatarUrl:
       "https://zrkselfyyqkkqcmxhjlt.supabase.co/storage/v1/object/public/images/1731427831515-thumbnail.webp",
     description: "저도 블로그 개발자입니다.",
   },
   {
-    accountId: "3",
+    id: "3",
+    email: "",
     username: "개발자3",
     avatarUrl:
       "https://zrkselfyyqkkqcmxhjlt.supabase.co/storage/v1/object/public/images/1731865249691-thumbnail.webp",

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -58,7 +58,7 @@ export async function signUp({
           id: authData.user.id,
           email,
           username,
-          avatar_url: `https://ui-avatars.com/api/?name=${encodeURIComponent(username)}`,
+          avatarUrl: `https://ui-avatars.com/api/?name=${encodeURIComponent(username)}`,
           description: description || null,
         },
       ])

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -294,14 +294,12 @@ export async function getFriends({
       .order("createdAt", { ascending: false }) // NOTE order 추후 변경 가능
       .range(offset, offset + limit - 1);
 
-    console.log("hi", data);
     if (error) throw error;
     if (!data) throw new Error("친구를 불러올 수 없습니다.");
 
     const friends = await Promise.all(
       data.map((request) => getUser(request.to)),
     );
-    console.log(friends);
 
     return {
       data: friends,

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -275,6 +275,46 @@ export async function getPosts({
 //
 // ============================================
 
+// 친구 조회
+export async function getFriends({
+  offset = 0,
+  limit = 12,
+}: {
+  offset?: number;
+  limit?: number;
+}): Promise<{ data: User[]; total: number; hasMore: boolean }> {
+  const user = { id: "8a49fc55-8604-4e9a-9c7d-b33a813f3344" };
+
+  try {
+    const { data, error, count } = await supabase
+      .from("friendRequest")
+      .select("to", { count: "exact" })
+      .eq("from", user.id)
+      .eq("isAccepted", true)
+      .order("createdAt", { ascending: false }) // NOTE order 추후 변경 가능
+      .range(offset, offset + limit - 1);
+
+    console.log("hi", data);
+    if (error) throw error;
+    if (!data) throw new Error("친구를 불러올 수 없습니다.");
+
+    const friends = await Promise.all(
+      data.map((request) => getUser(request.to)),
+    );
+    console.log(friends);
+
+    return {
+      data: friends,
+      total: count || 0,
+      hasMore: count ? offset + limit < count : false,
+    };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "친구 조회에 실패했습니다";
+    throw new Error(errorMessage);
+  }
+}
+
 // 친구요청 조회 조회
 export async function getFriendRequests({
   offset = 0,

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -299,26 +299,29 @@ export async function getFriendRequests({
       .select(
         `
           id,
-          from
+          from,
+          to
         `,
         { count: "exact" },
       )
       .eq("to", user.id)
-      .order("created_at", { ascending: false })
+      .is("isAccepted", null)
+      .order("createdAt", { ascending: false })
       .range(offset, offset + limit - 1);
 
     if (error) throw error;
     if (!data) throw new Error("친구 요청을 불러올 수 없습니다.");
 
     // FIXME 개선 필요
-    const froms = await Promise.all(
+    const fromUsers = await Promise.all(
       data.map((request) => getUser(request.from)),
     );
 
     return {
       data: data.map((request, idx) => ({
-        id: request.id,
-        from: froms[idx],
+        requestId: request.id,
+        toUserId: request.to,
+        fromUser: fromUsers[idx],
       })),
       total: count || 0,
       hasMore: count ? offset + limit < count : false,
@@ -326,6 +329,47 @@ export async function getFriendRequests({
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "친구 요청 조회에 실패했습니다";
+    throw new Error(errorMessage);
+  }
+}
+
+// 친구요청 생성
+export async function createFriendRequest(
+  from: string,
+  to: string,
+  isAccepted: boolean,
+) {
+  try {
+    const { error } = await supabase
+      .from("friendRequest")
+      .insert({ from, to, isAccepted });
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "친구 요청 생성에 실패했습니다";
+    throw new Error(errorMessage);
+  }
+}
+
+// 친구요청 반응 업데이트
+export async function putFriendRequest(requestId: string, isAccepted: boolean) {
+  try {
+    const { error } = await supabase
+      .from("friendRequest")
+      .update({ isAccepted })
+      .eq("id", requestId);
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "친구 요청 수정에 실패했습니다";
+    throw new Error(errorMessage);
+  }
+}
+
+export async function deleteFriendRequest(requestId: string) {
+  try {
+    await supabase.from("friendRequest").delete().eq("id", requestId);
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "친구 요청 삭제에 실패했습니다";
     throw new Error(errorMessage);
   }
 }
@@ -347,7 +391,7 @@ interface Post {
 }
 
 // 유저 타입 정의
-interface User {
+export interface User {
   id: string;
   email: string;
   username: string;
@@ -355,7 +399,9 @@ interface User {
   description: string;
 }
 
+// 친구 요청 정보 타입 정의
 interface RequestInfo {
-  id: string;
-  from: User;
+  requestId: string;
+  toUserId: string;
+  fromUser: User;
 }


### PR DESCRIPTION
## 📝 PR 설명
친구요청 수락/거절 기능을 구현했고, 친구 목록을 서버에서 받도록 변경했습니다.
아직 유저 정보가 저장되어있지 않아서 id "8a49fc55-8604-4e9a-9c7d-b33a813f3344"인 유저 기준으로 보여줍니다.
테스트 하실 때에는 새로 요청을 해당 아이디 가진 유저에게 보내야 하는데, 제가 미리 6개정도 만들어둘게요 ㅠㅠ
새로고침은 react-query 적용하고 하려고 빼뒀습니다 -> r 눌러서 새로고침 부탁드려요!!

## 🔍 변경사항
- 친구요청 수락 / 거절 기능 구현
- 친구목록 서버에서 로드

## 📸 스크린샷
| 친구 | 요청 |
|-|-|
|<img width="321" alt="image" src="https://github.com/user-attachments/assets/2855a959-2130-4558-be7d-1076fb333f12">|<img width="324" alt="image" src="https://github.com/user-attachments/assets/e34aad7a-c2a4-42e7-912a-795e64b03172">|



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 친구 목록을 가져오는 기능 추가.
	- 친구 요청 수락 및 거부 기능 개선.
	- 사용자 이메일 주소 저장을 위한 데이터 구조 변경.

- **버그 수정**
	- 요청 데이터 구조 업데이트로 인한 키 변경.

- **문서화**
	- 사용자 인터페이스와 요청 정보 인터페이스 수정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->