### PR TITLE
feat: 쉬는 날 설정 실패 시 토스트 표시

### DIFF
--- a/components/RestDayModal.tsx
+++ b/components/RestDayModal.tsx
@@ -1,18 +1,19 @@
-import { Alert, Text, TouchableOpacity, View } from "react-native";
-import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { Text, TouchableOpacity, View } from "react-native";
 
 import useCalendar from "@/hooks/useCalendar";
 
-import { addRestDay, deleteRestDay, getRestDays } from "@/utils/supabase";
 import { formatDate } from "@/utils/formatDate";
+import { addRestDay, deleteRestDay, getRestDays } from "@/utils/supabase";
 
-import CustomModal from "./Modal";
 import CalendarNavigator from "./CalendarNavigator";
+import CustomModal from "./Modal";
 import RestDayCalendar from "./RestDayCalendar";
 
-import icons from "@/constants/icons";
 import colors from "@/constants/colors";
+import icons from "@/constants/icons";
+import { showToast } from "./ToastConfig";
 
 type RestDay = Awaited<ReturnType<typeof getRestDays>>[number];
 
@@ -61,8 +62,8 @@ export default function RestDayModal({ visible, onClose }: RestDayModalProps) {
       queryClient.invalidateQueries({ queryKey: ["histories"] });
       queryClient.invalidateQueries({ queryKey: ["restDates"] });
     },
-    onError: (error) => {
-      Alert.alert("쉬는 날 설정 실패: ", error.message);
+    onError: () => {
+      showToast("fail", "쉬는 날 설정에 실패했어요!");
     },
   });
 

--- a/components/RestDayModal.tsx
+++ b/components/RestDayModal.tsx
@@ -62,7 +62,8 @@ export default function RestDayModal({ visible, onClose }: RestDayModalProps) {
       queryClient.invalidateQueries({ queryKey: ["histories"] });
       queryClient.invalidateQueries({ queryKey: ["restDates"] });
     },
-    onError: () => {
+    onError: (error) => {
+      console.error("쉬는 날 설정 실패:", error);
       showToast("fail", "쉬는 날 설정에 실패했어요!");
     },
   });


### PR DESCRIPTION
## 📝 PR 설명
쉬는 날 설정에 실패할 시 토스트로 표시합니다.

아래처럼 수정하시면 토스트 확인하실 수 있어요.
토스트 넘 귀엽네요.

RestDayModal.tsx
```tsx
  const { mutate: handleSubmit } = useMutation({
    mutationFn: async () => {
      // 생략
      throw Error;
    },
    onSuccess: () => {
      // 생략
    },
    onError: () => {
      showToast("fail", "쉬는 날 설정에 실패했어요!");
    },
  });
```

## 📸 스크린샷

<img src="https://github.com/user-attachments/assets/b8ed7bec-d9bd-4d5a-98af-ce2a41652f2e" width="200" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 오류 발생 시 사용자에게 표시되는 메시지를 `Alert.alert`에서 `showToast`로 변경하여 사용자 경험 개선.

- **기타 변경사항**
	- `RestDayModal`의 import 문서 순서 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->