### PR TITLE
fix: 친구, 알림 쿼리 키에 세션 정보 추가해서 로그아웃 시 정보 새로 받도록 변경

### DIFF
--- a/app/(tabs)/friend/index.tsx
+++ b/app/(tabs)/friend/index.tsx
@@ -1,23 +1,23 @@
-import { useEffect, useState } from "react";
-import { View, FlatList } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
 import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { FlatList, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
+import ErrorScreen from "@/components/ErrorScreen";
 import { FriendItem } from "@/components/FriendItem";
+import LoadingScreen from "@/components/LoadingScreen";
 import SearchBar from "@/components/SearchBar";
+import useFetchData from "@/hooks/useFetchData";
+import type { StatusInfo } from "@/types/Friend.interface";
+import type { UserProfile } from "@/types/User.interface";
+import { formatDate } from "@/utils/formatDate";
 import {
   getCurrentSession,
   getFriends,
   getFriendsStatus,
   supabase,
 } from "@/utils/supabase";
-import useFetchData from "@/hooks/useFetchData";
-import ErrorScreen from "@/components/ErrorScreen";
-import LoadingScreen from "@/components/LoadingScreen";
-import type { UserProfile } from "@/types/User.interface";
 import type { Session } from "@supabase/supabase-js";
-import type { StatusInfo } from "@/types/Friend.interface";
-import { formatDate } from "@/utils/formatDate";
 
 interface FriendLayoutProps {
   friends: UserProfile[];
@@ -66,7 +66,7 @@ export default function Friend() {
     isLoading: isFriendLoading,
     error: friendError,
   } = useFetchData<UserProfile[]>(
-    ["friends"],
+    ["friends", session?.user.id],
     () => getFriends(session?.user.id || ""),
     "친구 조회에 실패했습니다.",
     !!session?.user.id,
@@ -80,7 +80,7 @@ export default function Friend() {
     isLoading: isStatusLoading,
     error: statusError,
   } = useFetchData<StatusInfo[]>(
-    ["friendsStatus"],
+    ["friendsStatus", session?.user.id],
     () => getFriendsStatus(friendIds || []),
     "친구 조회에 실패했습니다.",
     !!friendIds?.length,

--- a/app/(tabs)/friend/request.tsx
+++ b/app/(tabs)/friend/request.tsx
@@ -34,7 +34,7 @@ export default function Request() {
     isLoading,
     error,
   } = useFetchData<RequestResponse>(
-    ["friendRequests", OFFSET],
+    ["friendRequests", session?.user.id, OFFSET],
     () => getFriendRequests(session?.user.id || ""),
     "친구 요청 조회에 실패했습니다.",
     !!session?.user,

--- a/app/notification.tsx
+++ b/app/notification.tsx
@@ -30,7 +30,7 @@ export default function Notification() {
     isLoading,
     error: notificationError,
   } = useFetchData<NotificationResponse[]>(
-    ["notification"],
+    ["notification", session?.user.id],
     () => getNotifications(session?.user.id || ""),
     "알림 조회에 실패했습니다.",
     !!session?.user,

--- a/hooks/useCheckNewNotification.ts
+++ b/hooks/useCheckNewNotification.ts
@@ -13,7 +13,7 @@ const useCheckNewNotification = () => {
 
   // 유저가 받은 마지막 알람 정보 조회
   const { data: lastNotificationTime } = useFetchData<string>(
-    ["lastNotification"],
+    ["lastNotification", user?.id],
     () => getLatestNotification(user?.id || ""),
     "마지막 알림 정보 조회에 실패했습니다.",
     !!user,


### PR DESCRIPTION
## 📝 PR 설명
로그아웃 하고 다른 아이디로 로그인 시 이전 계정 정보가 남아있어서, 새로 로드하도록 쿼리키 변경했습니다.
이외에도 다른 문제 있으면 알려주세요! 같이 고쳐서 올릴게요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 친구 목록 및 상태, 친구 요청, 알림을 사용자 세션에 맞춰 가져오는 기능 개선.
	- 알림 및 친구 요청의 실시간 업데이트를 사용자 세션에 기반하여 처리.

- **버그 수정**
	- 오류 처리 및 로딩 상태 관리 개선으로 사용자 경험 향상.

- **문서화**
	- 코드 구조 및 데이터 가져오기 로직의 명확성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->