### PR TITLE
feat: 게시글로 운동 인증하기 구현

### DIFF
--- a/app/(tabs)/upload.tsx
+++ b/app/(tabs)/upload.tsx
@@ -89,10 +89,15 @@ export default function Upload() {
   const addWorkoutHistoryMutation = useMutation({
     mutationFn: () => {
       const today = new Date();
-      const koreaTime = new Date(today.getTime() + 9 * 60 * 60 * 1000); // 한국 시간으로 변환
+      const koreaTime = new Intl.DateTimeFormat("ko-KR", {
+        timeZone: "Asia/Seoul",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).format(today);
 
       return addWorkoutHistory({
-        date: koreaTime.toISOString().split("T")[0], // 날짜만 추출
+        date: koreaTime,
       });
     },
     onError: () => {

--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -61,7 +61,7 @@ export default function PostItem({
   const router = useRouter();
 
   const user = useFetchData(
-    ["user"],
+    ["currentUser"],
     getCurrentUser,
     "사용자 정보를 불러오는데 실패했습니다.",
   );

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -116,7 +116,7 @@ export default function CommentItem({
   });
 
   const user = useFetchData(
-    ["user"],
+    ["currentUser"],
     getCurrentUser,
     "사용자 정보를 불러오는데 실패했습니다.",
   );

--- a/components/comments/CommentsSection.tsx
+++ b/components/comments/CommentsSection.tsx
@@ -67,7 +67,7 @@ export default function CommentsSection({
 
   // 유저 정보 가져오기
   const user = useFetchData(
-    ["user"],
+    ["currentUser"],
     getCurrentUser,
     "사용자 정보를 불러오는데 실패했습니다.",
   );

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -357,10 +357,9 @@ export type Database = {
             avatarUrl: string | null;
           };
           likes: number;
-          parentsCommentId: number | null;
-          replyCommentId: number | null;
           isLiked: boolean;
           likedAvatars: string[];
+          parentsCommentId: number;
           totalReplies: number;
         }[];
       };

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1078,6 +1078,42 @@ export async function deleteRestDay(
   }
 }
 
+// 운동 기록 추가
+export async function addWorkoutHistory({ date }: { date: string }) {
+  const { user } = await getCurrentSession();
+
+  const { data: todayHistory, error: selectError } = await supabase
+    .from("workoutHistory")
+    .select("date")
+    .eq("userId", user.id)
+    .eq("date", date)
+    .single();
+
+  if (selectError && selectError.code !== "PGRST116") {
+    throw selectError;
+  }
+
+  if (todayHistory) {
+    return todayHistory;
+  }
+
+  const { data, error: insertError } = await supabase
+    .from("workoutHistory")
+    .insert([
+      {
+        userId: user.id,
+        date,
+        status: "done",
+      },
+    ]);
+
+  if (insertError) {
+    throw insertError;
+  }
+
+  return { message: "운동 기록이 추가되었습니다." };
+}
+
 // ============================================
 //
 //                 notification
@@ -1158,16 +1194,6 @@ export async function createNotification(notification: Notification) {
 //                    type
 //
 // ============================================
-
-// 게시글 타입 정의
-interface Post {
-  id: string;
-  images: string[];
-  contents: string;
-  createdAt: string;
-  likes: number;
-  // author: User;
-}
 
 // 운동 기록 타입 정의
 type HistoryDate = `${number}-${number}-${number}`;


### PR DESCRIPTION
## 📝 PR 설명
게시글 작성하면 인증이 되고 하루에 게시글 여러번 작성은 가능하지만 인증은 한번만 전송되게 해뒀습니다
인증 반영도 잘 되는거 같습니다
![image](https://github.com/user-attachments/assets/a6e65a94-2654-4da0-88fa-d9294843e969)
![image](https://github.com/user-attachments/assets/7c83778b-73c2-405b-a55b-63d63be21560)
![KakaoTalk_20241208_021041552](https://github.com/user-attachments/assets/b6ef8e43-a522-49ef-881c-330ed1ec4253)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 운동 기록 추가 기능이 도입되었습니다.
	- 업로드 기능이 개선되어 운동 기록과 게시물 업로드가 동시에 처리됩니다.
	- 댓글 섹션의 사용자 경험이 향상되었습니다. (키보드 이벤트 처리 및 댓글 목록 새로 고침 기능 추가)
- **버그 수정**
	- 게시물 편집 후 네비게이션 동작이 "/home" 경로로 변경되었습니다.
- **문서화**
	- `get_comments` 함수의 반환 타입이 변경되어 필수 필드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->