### PR TITLE
feat: 다른 유저 페이지에서 친구 요청, 수락, 끊기 가능하도록 구현

### DIFF
--- a/app/(tabs)/friend/index.tsx
+++ b/app/(tabs)/friend/index.tsx
@@ -19,6 +19,7 @@ import {
   supabase,
 } from "@/utils/supabase";
 import type { Session } from "@supabase/supabase-js";
+import { useFocusEffect } from "expo-router";
 
 interface FriendLayoutProps {
   friends: UserProfile[];
@@ -99,6 +100,13 @@ export default function Friend() {
   const handleKeywordChange = debounce((newKeyword: string) => {
     setKeyword(newKeyword);
   }, 500);
+
+  // 친구창에 focus 들어올 때마다 친구목록 새로고침 (검색중일 때 제외)
+  useFocusEffect(() => {
+    if (!keyword) {
+      queryClient.invalidateQueries({ queryKey: ["friends"] });
+    }
+  });
 
   // 친구의 운동 정보가 바뀌면 쿼리 다시 패치하도록 정보 구독
   useEffect(() => {

--- a/app/(tabs)/friend/request.tsx
+++ b/app/(tabs)/friend/request.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/utils/supabase";
 import type { Session } from "@supabase/supabase-js";
 import { useQueryClient } from "@tanstack/react-query";
+import { useFocusEffect } from "expo-router";
 
 const OFFSET = 0;
 const LIMIT = 12;
@@ -39,6 +40,11 @@ export default function Request() {
     "친구 요청 조회에 실패했습니다.",
     !!session?.user,
   );
+
+  // 친구 요청창에 focus 들어올 때마다 친구목록 새로고침
+  useFocusEffect(() => {
+    queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
+  });
 
   // 친구 요청이 추가되면 쿼리 다시 패치하도록 정보 구독
   useEffect(() => {

--- a/components/FriendItem.tsx
+++ b/components/FriendItem.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "expo-router";
 import { useEffect } from "react";
 import { Image, Text, TouchableOpacity, View } from "react-native";
@@ -7,20 +7,12 @@ import icons from "@/constants/icons";
 import images from "@/constants/images";
 import { POKE_TIME } from "@/constants/time";
 import useFetchData from "@/hooks/useFetchData";
+import useManageFriend from "@/hooks/useManageFriend";
 import { useTimerWithStartAndDuration } from "@/hooks/useTimer";
-import { NOTIFICATION_TYPE } from "@/types/Notification.interface";
 import type { UserProfile } from "@/types/User.interface";
 import { formatTime } from "@/utils/formatTime";
-import {
-  createFriendRequest,
-  createNotification,
-  deleteFriendRequest,
-  getCurrentSession,
-  getLatestStabForFriend,
-  putFriendRequest,
-} from "@/utils/supabase";
+import { getCurrentSession, getLatestStabForFriend } from "@/utils/supabase";
 import type { Session } from "@supabase/supabase-js";
-import { showToast } from "./ToastConfig";
 
 /* Interfaces */
 
@@ -85,28 +77,8 @@ export function FriendItem({ friend }: FriendItemProps) {
   const { timeLeft, start: timerStart } = useTimerWithStartAndDuration();
   const isPokeDisable = !!friend.status || !!timeLeft;
 
-  // 친구 콕 찌르기
-  const { mutate: handlePoke } = useMutation({
-    mutationFn: async () => {
-      if (!user?.id) throw new Error("로그인한 유저 정보가 없습니다.");
-
-      await createNotification({
-        from: user.id,
-        to: friend.id,
-        type: NOTIFICATION_TYPE.POKE,
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["poke", user?.id, friend.id],
-      });
-      showToast("success", `👈 ${friend.username}님을 콕! 찔렀어요`);
-    },
-    onError: (error) => {
-      console.error("콕 찌르기 실패:", error);
-      showToast("fail", "콕 찌르기에 실패했어요!");
-    },
-  });
+  const { usePoke } = useManageFriend();
+  const { mutate: handlePoke } = usePoke({ userId: user?.id, friend });
 
   useEffect(() => {
     if (lastPokeCreatedAt) timerStart(Date.parse(lastPokeCreatedAt), POKE_TIME);
@@ -151,37 +123,11 @@ export function FriendRequest({
 }: FriendRequestProps) {
   const queryClient = useQueryClient();
 
-  // 친구 요청 수락
-  const { mutate: handleAccept, isPending: isAcceptPending } = useMutation({
-    mutationFn: async () => {
-      await Promise.all([
-        putFriendRequest(requestId, true),
-        createFriendRequest(toUserId, fromUser.id, true),
-      ]);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
-      queryClient.invalidateQueries({ queryKey: ["friends"] });
-    },
-    onError: (error) => {
-      console.error("친구 요청 수락 실패:", error);
-      showToast("fail", "요청 수락에 실패했어요!");
-    },
-  });
-
-  // 친구 요청 거절
-  const { mutate: handleRefuse, isPending: isRefusePending } = useMutation({
-    mutationFn: async () => {
-      await deleteFriendRequest(requestId);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
-    },
-    onError: (error) => {
-      console.error("친구 요청 거절 실패:", error);
-      showToast("fail", "요청 거절에 실패했어요!");
-    },
-  });
+  const { useAcceptRequest, useRefuseRequest } = useManageFriend();
+  const { mutate: handleAccept, isPending: isAcceptPending } =
+    useAcceptRequest();
+  const { mutate: handleRefuse, isPending: isRefusePending } =
+    useRefuseRequest();
 
   return (
     <View className="py-4 border-b-[1px] border-gray-25 flex-row justify-between items-center">
@@ -190,7 +136,9 @@ export function FriendRequest({
       <View className="flex-row gap-[11px]">
         <TouchableOpacity
           className="bg-primary px-[12px] py-[11px] rounded-[10px]"
-          onPress={() => handleAccept()}
+          onPress={() =>
+            handleAccept({ requestId, fromUserId: fromUser.id, toUserId })
+          }
           disabled={isAcceptPending || isRefusePending || isLoading}
           accessibilityLabel="친구 요청 수락"
           accessibilityHint="이 버튼을 누르면 친구 요청을 수락합니다"
@@ -200,7 +148,7 @@ export function FriendRequest({
 
         <TouchableOpacity
           className="bg-white  px-[12px] py-[11px] rounded-[10px] border-primary border-[1px]"
-          onPress={() => handleRefuse()}
+          onPress={() => handleRefuse({ requestId })}
           disabled={isAcceptPending || isRefusePending || isLoading}
           accessibilityLabel="친구 요청 거절"
           accessibilityHint="이 버튼을 누르면 친구 요청을 거절합니다"

--- a/components/FriendItem.tsx
+++ b/components/FriendItem.tsx
@@ -78,7 +78,7 @@ export function FriendItem({ friend }: FriendItemProps) {
   const isPokeDisable = !!friend.status || !!timeLeft;
 
   const { usePoke } = useManageFriend();
-  const { mutate: handlePoke } = usePoke({ userId: user?.id, friend });
+  const { mutate: handlePoke } = usePoke();
 
   useEffect(() => {
     if (lastPokeCreatedAt) timerStart(Date.parse(lastPokeCreatedAt), POKE_TIME);
@@ -93,7 +93,7 @@ export function FriendItem({ friend }: FriendItemProps) {
         disabled={isPokeDisable}
         accessibilityLabel="친구 찌르기"
         accessibilityHint="이 버튼을 누르면 친구에게 찌르기 알람을 보냅니다"
-        onPress={() => handlePoke()}
+        onPress={() => handlePoke({ userId: user?.id, friend })}
       >
         {friend.status === "done" ? (
           <View className="flex-row items-center justify-center">
@@ -148,7 +148,9 @@ export function FriendRequest({
 
         <TouchableOpacity
           className="bg-white  px-[12px] py-[11px] rounded-[10px] border-primary border-[1px]"
-          onPress={() => handleRefuse({ requestId })}
+          onPress={() =>
+            handleRefuse({ requestId, fromUserId: fromUser.id, toUserId })
+          }
           disabled={isAcceptPending || isRefusePending || isLoading}
           accessibilityLabel="친구 요청 거절"
           accessibilityHint="이 버튼을 누르면 친구 요청을 거절합니다"

--- a/hooks/useManageFriend.ts
+++ b/hooks/useManageFriend.ts
@@ -85,7 +85,6 @@ const useManageFriend = () => {
           ? await checkFriendRequest(String(requestId))
           : await checkFriendRequestWithUserId(fromUserId, toUserId);
         if (!hasFriendRequest) {
-          console.log("dd");
           throw new NoRequestError(
             "친구 요청이 유효하지 않습니다.",
             fromUserId,

--- a/hooks/useManageFriend.ts
+++ b/hooks/useManageFriend.ts
@@ -5,18 +5,32 @@ import {
   createFriendRequest,
   createNotification,
   deleteFriendRequest,
+  deleteFriendRequestWithUserId,
   putFriendRequest,
+  putFriendRequestWithUserId,
 } from "@/utils/supabase";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+interface CreateProps {
+  fromUserId: string;
+  toUserId: string;
+}
+
 interface AcceptProps {
-  requestId: number;
+  requestId?: number;
   fromUserId: string;
   toUserId: string;
 }
 
 interface RefuseProps {
   requestId: number;
+  fromUserId: string;
+  toUserId: string;
+}
+
+interface UnfriendProps {
+  fromUserId: string;
+  toUserId: string;
 }
 
 interface PokeProps {
@@ -27,19 +41,46 @@ interface PokeProps {
 const useManageFriend = () => {
   const queryClient = useQueryClient();
 
-  // 친구 요청 수락
-  const useAcceptRequest = () => {
-    const { mutate, isPending } = useMutation<void, Error, AcceptProps>({
-      mutationFn: async ({ requestId, fromUserId, toUserId }) => {
-        await Promise.all([
-          putFriendRequest(requestId, true),
-          createFriendRequest(toUserId, fromUserId, true),
-        ]);
+  // 친구 요청 생성
+  const useCreateRequest = () => {
+    const { mutate, isPending } = useMutation<CreateProps, Error, CreateProps>({
+      mutationFn: async ({ fromUserId, toUserId }) => {
+        await createFriendRequest(fromUserId, toUserId, null);
+        return { fromUserId, toUserId };
       },
-      onSuccess: () => {
-        console.log("accept success");
+      onSuccess: ({ fromUserId, toUserId }) => {
         queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
         queryClient.invalidateQueries({ queryKey: ["friends"] });
+        queryClient.invalidateQueries({
+          queryKey: ["relation", fromUserId, toUserId],
+        });
+      },
+      onError: (error) => {
+        console.error("친구 요청 생성 실패:", error);
+        showToast("fail", "요청 보내기에 실패했어요!");
+      },
+    });
+    return { mutate, isPending };
+  };
+
+  // 친구 요청 수락
+  const useAcceptRequest = () => {
+    const { mutate, isPending } = useMutation<AcceptProps, Error, AcceptProps>({
+      mutationFn: async ({ requestId, fromUserId, toUserId }) => {
+        await Promise.all([
+          requestId
+            ? putFriendRequest(requestId, true)
+            : putFriendRequestWithUserId(fromUserId, toUserId, true),
+          createFriendRequest(toUserId, fromUserId, true),
+        ]);
+        return { fromUserId, toUserId };
+      },
+      onSuccess: ({ fromUserId, toUserId }) => {
+        queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
+        queryClient.invalidateQueries({ queryKey: ["friends"] });
+        queryClient.invalidateQueries({
+          queryKey: ["relation", toUserId, fromUserId],
+        });
       },
       onError: (error) => {
         console.error("친구 요청 수락 실패:", error);
@@ -52,13 +93,16 @@ const useManageFriend = () => {
 
   // 친구 요청 거절
   const useRefuseRequest = () => {
-    const { mutate, isPending } = useMutation<void, Error, RefuseProps>({
-      mutationFn: async ({ requestId }) => {
+    const { mutate, isPending } = useMutation<RefuseProps, Error, RefuseProps>({
+      mutationFn: async ({ requestId, fromUserId, toUserId }) => {
         await deleteFriendRequest(requestId);
+        return { requestId, fromUserId, toUserId };
       },
-      onSuccess: () => {
-        console.log("refuse success");
+      onSuccess: ({ fromUserId, toUserId }) => {
         queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
+        queryClient.invalidateQueries({
+          queryKey: ["relation", fromUserId, toUserId],
+        });
       },
       onError: (error) => {
         console.error("친구 요청 거절 실패:", error);
@@ -68,22 +112,50 @@ const useManageFriend = () => {
     return { mutate, isPending };
   };
 
+  // 친구 끊기
+  const useUnfriend = () => {
+    const { mutate, isPending } = useMutation<
+      UnfriendProps,
+      Error,
+      UnfriendProps
+    >({
+      mutationFn: async ({ fromUserId, toUserId }) => {
+        await Promise.all([
+          deleteFriendRequestWithUserId(fromUserId, toUserId),
+          deleteFriendRequestWithUserId(toUserId, fromUserId),
+        ]);
+        return { fromUserId, toUserId };
+      },
+      onSuccess: ({ fromUserId, toUserId }) => {
+        queryClient.invalidateQueries({ queryKey: ["friends"] });
+        queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
+        queryClient.invalidateQueries({
+          queryKey: ["relation", fromUserId, toUserId],
+        });
+      },
+      onError: (error) => {
+        console.error("친구 끊기 실패:", error);
+        showToast("fail", "친구 끊기를 실패했어요!");
+      },
+    });
+    return { mutate, isPending };
+  };
+
   // 친구 콕 찌르기
-  const usePoke = ({ userId, friend }: PokeProps) => {
-    const { mutate } = useMutation({
-      mutationFn: async () => {
-        if (!userId) {
-          showToast("fail", "계정 정보가 없습니다.");
-          return;
-        }
+  const usePoke = () => {
+    const { mutate } = useMutation<PokeProps, Error, PokeProps>({
+      mutationFn: async ({ userId, friend }) => {
+        if (!userId) throw new Error("계정 정보가 없습니다.");
 
         await createNotification({
           from: userId,
           to: friend.id,
           type: NOTIFICATION_TYPE.POKE,
         });
+
+        return { userId, friend };
       },
-      onSuccess: () => {
+      onSuccess: ({ userId, friend }) => {
         if (!userId) return;
 
         queryClient.invalidateQueries({
@@ -100,7 +172,13 @@ const useManageFriend = () => {
     return { mutate };
   };
 
-  return { useAcceptRequest, useRefuseRequest, usePoke };
+  return {
+    useCreateRequest,
+    useAcceptRequest,
+    useRefuseRequest,
+    useUnfriend,
+    usePoke,
+  };
 };
 
 export default useManageFriend;

--- a/hooks/useManageFriend.ts
+++ b/hooks/useManageFriend.ts
@@ -2,14 +2,13 @@ import { showToast } from "@/components/ToastConfig";
 import { NOTIFICATION_TYPE } from "@/types/Notification.interface";
 import type { UserProfile } from "@/types/User.interface";
 import {
+  acceptFriendRequest,
   checkFriendRequest,
   checkFriendRequestWithUserId,
   createFriendRequest,
   createNotification,
   deleteFriendRequest,
   deleteFriendRequestWithUserId,
-  putFriendRequest,
-  putFriendRequestWithUserId,
 } from "@/utils/supabase";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
@@ -92,12 +91,7 @@ const useManageFriend = () => {
           );
         }
 
-        await Promise.all([
-          requestId
-            ? putFriendRequest(requestId, true)
-            : putFriendRequestWithUserId(fromUserId, toUserId, true),
-          createFriendRequest(toUserId, fromUserId, true),
-        ]);
+        await acceptFriendRequest(fromUserId, toUserId, requestId);
         return { fromUserId, toUserId };
       },
       onSuccess: ({ fromUserId, toUserId }) => {

--- a/hooks/useManageFriend.ts
+++ b/hooks/useManageFriend.ts
@@ -1,0 +1,106 @@
+import { showToast } from "@/components/ToastConfig";
+import { NOTIFICATION_TYPE } from "@/types/Notification.interface";
+import type { UserProfile } from "@/types/User.interface";
+import {
+  createFriendRequest,
+  createNotification,
+  deleteFriendRequest,
+  putFriendRequest,
+} from "@/utils/supabase";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+interface AcceptProps {
+  requestId: number;
+  fromUserId: string;
+  toUserId: string;
+}
+
+interface RefuseProps {
+  requestId: number;
+}
+
+interface PokeProps {
+  userId?: string;
+  friend: UserProfile;
+}
+
+const useManageFriend = () => {
+  const queryClient = useQueryClient();
+
+  // 친구 요청 수락
+  const useAcceptRequest = () => {
+    const { mutate, isPending } = useMutation<void, Error, AcceptProps>({
+      mutationFn: async ({ requestId, fromUserId, toUserId }) => {
+        await Promise.all([
+          putFriendRequest(requestId, true),
+          createFriendRequest(toUserId, fromUserId, true),
+        ]);
+      },
+      onSuccess: () => {
+        console.log("accept success");
+        queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
+        queryClient.invalidateQueries({ queryKey: ["friends"] });
+      },
+      onError: (error) => {
+        console.error("친구 요청 수락 실패:", error);
+        showToast("fail", "요청 수락에 실패했어요!");
+      },
+    });
+
+    return { mutate, isPending };
+  };
+
+  // 친구 요청 거절
+  const useRefuseRequest = () => {
+    const { mutate, isPending } = useMutation<void, Error, RefuseProps>({
+      mutationFn: async ({ requestId }) => {
+        await deleteFriendRequest(requestId);
+      },
+      onSuccess: () => {
+        console.log("refuse success");
+        queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
+      },
+      onError: (error) => {
+        console.error("친구 요청 거절 실패:", error);
+        showToast("fail", "요청 거절에 실패했어요!");
+      },
+    });
+    return { mutate, isPending };
+  };
+
+  // 친구 콕 찌르기
+  const usePoke = ({ userId, friend }: PokeProps) => {
+    const { mutate } = useMutation({
+      mutationFn: async () => {
+        if (!userId) {
+          showToast("fail", "계정 정보가 없습니다.");
+          return;
+        }
+
+        await createNotification({
+          from: userId,
+          to: friend.id,
+          type: NOTIFICATION_TYPE.POKE,
+        });
+      },
+      onSuccess: () => {
+        if (!userId) return;
+
+        queryClient.invalidateQueries({
+          queryKey: ["poke", userId, friend.id],
+        });
+        showToast("success", `👈 ${friend.username}님을 콕! 찔렀어요`);
+      },
+      onError: (error) => {
+        console.error("콕 찌르기 실패:", error);
+        showToast("fail", "콕 찌르기에 실패했어요!");
+      },
+    });
+
+    return { mutate };
+  };
+
+  return { useAcceptRequest, useRefuseRequest, usePoke };
+};
+
+export default useManageFriend;

--- a/types/Friend.interface.ts
+++ b/types/Friend.interface.ts
@@ -1,5 +1,13 @@
 import type { StatusType, UserProfile } from "./User.interface";
 
+export const RELATION_TYPE = {
+  ASKING: "asking", // 내가 친구 요청 보냄
+  ASKED: "asked", // 친구 요청 받음
+  FRIEND: "friend", // 친구
+  NONE: "none", // 서로 아무 관계 아님
+} as const;
+export type RelationType = (typeof RELATION_TYPE)[keyof typeof RELATION_TYPE];
+
 export interface RequestInfo {
   requestId: number;
   toUserId: string;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -334,6 +334,14 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
+      accept_friend_request: {
+        Args: {
+          request_id: number | null;
+          from_user_id: string;
+          to_user_id: string;
+        };
+        Returns: undefined;
+      };
       decrement_comment_likes: {
         Args: {
           p_comment_id: number;

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1137,27 +1137,16 @@ export async function createFriendRequest(
   if (error) throw error;
 }
 
-// 친구요청 반응 업데이트
-export async function putFriendRequest(requestId: number, isAccepted: boolean) {
-  const { error } = await supabase
-    .from("friendRequest")
-    .update({ isAccepted })
-    .eq("id", requestId);
-
-  if (error) throw error;
-}
-
-// 친구요청 반응 업데이트
-export async function putFriendRequestWithUserId(
-  from: string,
-  to: string,
-  isAccepted: boolean,
+export async function acceptFriendRequest(
+  fromUserId: string,
+  toUserId: string,
+  requestId: number | null = null,
 ) {
-  const { error } = await supabase
-    .from("friendRequest")
-    .update({ isAccepted })
-    .eq("from", from)
-    .eq("to", to);
+  const { data, error } = await supabase.rpc("accept_friend_request", {
+    from_user_id: fromUserId,
+    request_id: requestId,
+    to_user_id: toUserId,
+  });
 
   if (error) throw error;
 }

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1060,7 +1060,7 @@ export async function getFriendsStatus(
   return data;
 }
 
-// 친구요청 조회 조회
+// 친구요청 조회
 export async function getFriendRequests(
   userId: string,
   offset = 0,
@@ -1093,6 +1093,37 @@ export async function getFriendRequests(
     total: count || 0,
     hasMore: count ? offset + limit < count : false,
   };
+}
+
+// 친구요청 있는지 조회
+export async function checkFriendRequest(requestId: string): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("friendRequest")
+    .select("id")
+    .eq("id", requestId);
+
+  if (error) throw error;
+  if (!data) throw new Error("친구 요청을 불러올 수 없습니다.");
+
+  console.log(!!data.length);
+  return !!data.length;
+}
+
+export async function checkFriendRequestWithUserId(
+  from: string,
+  to: string,
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("friendRequest")
+    .select("id")
+    .eq("from", from)
+    .eq("to", to);
+
+  if (error) throw error;
+  if (!data) throw new Error("친구 요청을 불러올 수 없습니다.");
+  console.log(!!data.length);
+
+  return !!data.length;
 }
 
 // 친구요청 생성

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1105,7 +1105,6 @@ export async function checkFriendRequest(requestId: string): Promise<boolean> {
   if (error) throw error;
   if (!data) throw new Error("친구 요청을 불러올 수 없습니다.");
 
-  console.log(!!data.length);
   return !!data.length;
 }
 
@@ -1121,7 +1120,6 @@ export async function checkFriendRequestWithUserId(
 
   if (error) throw error;
   if (!data) throw new Error("친구 요청을 불러올 수 없습니다.");
-  console.log(!!data.length);
 
   return !!data.length;
 }

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -5,7 +5,12 @@ import { decode } from "base64-arraybuffer";
 import * as FileSystem from "expo-file-system";
 import type * as ImagePicker from "expo-image-picker";
 
-import type { RequestResponse, StatusInfo } from "@/types/Friend.interface";
+import {
+  RELATION_TYPE,
+  type RelationType,
+  type RequestResponse,
+  type StatusInfo,
+} from "@/types/Friend.interface";
 import type { NotificationResponse } from "@/types/Notification.interface";
 import type { Notification } from "@/types/Notification.interface";
 import type { User, UserProfile } from "@/types/User.interface";
@@ -891,6 +896,52 @@ export async function getFriends(userId: string): Promise<UserProfile[]> {
   return data.map(({ to }) => to as UserProfile);
 }
 
+export async function getFriendStatus(
+  userId: string,
+  friendId: string,
+): Promise<RelationType> {
+  // 내가 보낸 요청
+  const { data: asking, error: askingError } = await supabase
+    .from("friendRequest")
+    .select("isAccepted")
+    .eq("from", userId)
+    .eq("to", friendId)
+    .limit(1);
+  if (askingError) throw askingError;
+
+  // 내가 받은 요청
+  const { data: asked, error: askedError } = await supabase
+    .from("friendRequest")
+    .select("isAccepted")
+    .eq("from", friendId)
+    .eq("to", userId)
+    .limit(1);
+  if (askedError) throw askedError;
+
+  if (!asked || !asking)
+    throw new Error(
+      `친구 관계를 불러올 수 없습니다.
+      asking: ${asking}, asked: ${asked}`,
+    );
+
+  // 서로 친구 요청 없으면 NONE
+  if (!asked.length && !asking.length) return RELATION_TYPE.NONE;
+  // 내가 보낸 요청만 있고, 아직 수락 전이면 ASKING
+  if (!asked.length && asking[0]?.isAccepted === null)
+    return RELATION_TYPE.ASKING;
+  // 내가 받은 요청만 있고, 아직 수락 전이면 ASKED
+  if (asked[0]?.isAccepted === null && !asking.length)
+    return RELATION_TYPE.ASKED;
+  // 서로 친구요청 수락 상태면 FRIEND
+  if (asked[0]?.isAccepted && asking[0]?.isAccepted)
+    return RELATION_TYPE.FRIEND;
+
+  // 나머지는 DB가 잘못된 상황
+  throw new Error(`친구 DB 확인 필요합니다!
+    내 요청: ${asking[0]?.isAccepted}
+    상대방 요청: ${asked[0]?.isAccepted}`);
+}
+
 // 모든 친구의 운동 상태 조회
 export async function getFriendsStatus(
   friendIds: string[],
@@ -967,12 +1018,38 @@ export async function putFriendRequest(requestId: number, isAccepted: boolean) {
   if (error) throw error;
 }
 
+// 친구요청 반응 업데이트
+export async function putFriendRequestWithUserId(
+  from: string,
+  to: string,
+  isAccepted: boolean,
+) {
+  const { error } = await supabase
+    .from("friendRequest")
+    .update({ isAccepted })
+    .eq("from", from)
+    .eq("to", to);
+
+  if (error) throw error;
+}
+
 // 친구 요청 삭제
 export async function deleteFriendRequest(requestId: number) {
   const { error } = await supabase
     .from("friendRequest")
     .delete()
     .eq("id", requestId);
+
+  if (error) throw error;
+}
+
+// 유저 아이디로 친구 요청 삭제
+export async function deleteFriendRequestWithUserId(from: string, to: string) {
+  const { error } = await supabase
+    .from("friendRequest")
+    .delete()
+    .eq("from", from)
+    .eq("to", to);
 
   if (error) throw error;
 }


### PR DESCRIPTION
## 📝 PR 설명
친구 기능을 관리하는 훅을 따로 만들어 공통으로 사용하도록 리팩토링 했고, 다른 유저의 페이지에서 친구 요청, 요청 수락, 친구 끊기가 가능하게 했습니다.

## 🔍 변경사항
- 친구 기능 리팩토링 (훅으로 이용 가능)
- 다른 유저 페이지에서 친구 수락 / 친구 끊기 / 친구 요청 가능

## 확인 요청
지금 졸려서 잘못된 부분 있을수도 있습니다. 다들 잘 동작하는지 확인 부탁드려요!
- ~친구 수락 하자마자 바로 친구 끊기가 안됩니다. (왜인지 getFriendStatus 에러 발생) 다른 페이지 갔다 오면 돼서 당장 사용에 큰 문제는 없습니다.~
- ~친구 페이지에 머무는 중에 상대방이 요청 수락하면 문제가 될 수 있습니다.~
  - ~상태가 내가 요청 보낸 상태인데, 서버를 구독하지 않는 이상 상대방이 수락해서 이미 친구가 된 것을 내가 알 수 없기 때문입니다.~
  - ~구독으로도 DELETE의 경우 정보가 삭제된 requestId 뿐이라서 이건 해결이 어려울 것 같아요~

-> insert 되는 경우는 구독으로 해결해서 문제 없어야 하고, delete되는 경우 아래와 같습니다.
A -> B 요청, A -X-> B 요청 취소, B -> A 수락 시 => 수락에서 에러 토스트 띄우고 새로고침 (이후 정상작동) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 관계 관리 기능 향상: 친구 요청 상태에 따라 동작하는 `RequestButton` 추가.
	- 친구 요청 상태를 확인하는 `getFriendStatus` 기능 추가.
	- 친구 요청 생성, 수락, 거부, 친구 삭제 및 알림 기능을 관리하는 `useManageFriend` 커스텀 훅 추가.
	- 친구 목록과 친구 요청 데이터를 실시간으로 새로 고치는 `useFocusEffect` 추가.

- **버그 수정**
	- 친구 관계 상태에 따른 UI 업데이트 및 오류 처리 개선.

- **문서화**
	- 새로운 타입 `RelationType` 및 상수 `RELATION_TYPE` 추가로 관계 상태를 타입 안전하게 표현.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->