### PR TITLE
feat: 게시글 상세 페이지 구현

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -75,7 +75,7 @@ export default function Home() {
             }}
             images={post.images}
             liked={post.isLikedByUser}
-            likedAuthorAvatar={post.likedAvatars ?? []}
+            likedAuthorAvatars={post.likedAvatars ?? []}
             contents={post.contents}
             createdAt={post.createdAt}
             commentsCount={post.totalComments ?? 0}

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -1,20 +1,20 @@
+import CustomModal from "@/components/Modal";
+import colors from "@/constants/colors";
+import Icons from "@/constants/icons";
+import images from "@/constants/images";
+import useFetchData from "@/hooks/useFetchData";
+import { getCurrentUser, getMyPosts } from "@/utils/supabase";
+import { useRouter } from "expo-router";
+import { useState } from "react";
 import {
-  View,
-  Text,
-  Image,
-  FlatList,
   Dimensions,
+  FlatList,
+  Image,
+  Text,
   TouchableOpacity,
+  View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { getCurrentUser, getMyPosts } from "@/utils/supabase";
-import images from "@/constants/images";
-import Icons from "@/constants/icons";
-import colors from "@/constants/colors";
-import { useState } from "react";
-import CustomModal from "@/components/Modal";
-import { useRouter } from "expo-router";
-import useFetchData from "@/hooks/useFetchData";
 
 export default function MyPage() {
   const router = useRouter();
@@ -88,16 +88,20 @@ export default function MyPage() {
                     style={{ height: size, width: size }}
                     className="bg-gray-5"
                   >
-                    <Image
-                      source={{ uri: item.images[0] }}
-                      resizeMode="cover"
-                      style={{ width: "100%", height: "100%" }}
-                    />
+                    <TouchableOpacity
+                      onPress={() => router.push(`/post/${item.id}`)}
+                    >
+                      <Image
+                        source={{ uri: item.images[0] }}
+                        resizeMode="cover"
+                        style={{ width: "100%", height: "100%" }}
+                      />
+                    </TouchableOpacity>
                   </View>
                 );
               }}
               numColumns={3}
-              keyExtractor={(item) => item.id}
+              keyExtractor={(item) => item.id.toString()}
               className="mt-[32px]"
             />
           ) : (

--- a/app/(tabs)/upload.tsx
+++ b/app/(tabs)/upload.tsx
@@ -29,6 +29,13 @@ export default function Upload() {
   const [isInfoModalVisible, setIsInfoModalVisible] = useState(false);
   const queryClient = useQueryClient();
 
+  const post = useFetchData(
+    ["post", postId],
+    () => (postId ? getPost(postId) : Promise.resolve(null)),
+    "게시글을 불러오는 도중 에러가 발생했습니다.",
+    postId !== undefined,
+  );
+
   useFocusEffect(
     useCallback(() => {
       if (postId) {
@@ -42,14 +49,7 @@ export default function Upload() {
           }
         });
       }
-    }, [postId]),
-  );
-
-  const post = useFetchData(
-    ["post", postId],
-    () => (postId ? getPost(postId) : Promise.resolve(null)),
-    "게시글을 불러오는 도중 에러가 발생했습니다.",
-    postId !== undefined,
+    }, [postId, post.refetch]),
   );
 
   useEffect(() => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,18 +1,18 @@
 import { useReactQueryDevTools } from "@dev-plugins/react-query";
+import type { Session } from "@supabase/supabase-js";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect, useState } from "react";
 import Toast from "react-native-toast-message";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { Session } from "@supabase/supabase-js";
 
 import "../global.css";
-import { useFonts } from "expo-font";
 import { HeaderWithBack } from "@/components/Header";
-import { supabase } from "@/utils/supabase";
-import { useOnlineManager } from "@/hooks/useOnlineManager";
-import { useAppState } from "@/hooks/useAppState";
 import { ToastConfig } from "@/components/ToastConfig";
+import { useAppState } from "@/hooks/useAppState";
+import { useOnlineManager } from "@/hooks/useOnlineManager";
+import { supabase } from "@/utils/supabase";
+import { useFonts } from "expo-font";
 
 SplashScreen.preventAutoHideAsync();
 
@@ -85,6 +85,7 @@ export default function RootLayout() {
           }}
         />
         <Stack.Screen name="user/[userId]" options={{ headerShown: false }} />
+        <Stack.Screen name="post/[postId]" options={{ headerShown: false }} />
       </Stack>
       <Toast config={ToastConfig} />
     </QueryClientProvider>

--- a/app/post/[postId].tsx
+++ b/app/post/[postId].tsx
@@ -7,7 +7,7 @@ import Icons from "@/constants/icons";
 import images from "@/constants/images";
 import useFetchData from "@/hooks/useFetchData";
 import { getCurrentUser, getPost, getPostLikes } from "@/utils/supabase";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useState } from "react";
 import { FlatList, Image, Text, TouchableOpacity } from "react-native";
 import { Dimensions, View } from "react-native";
@@ -43,6 +43,10 @@ export default function PostDetail() {
     "좋아요한 사용자 정보를 불러오는데 실패했습니다.",
     isLikedModalVisible,
   );
+
+  useFocusEffect(() => {
+    if (!post) router.back();
+  });
 
   const onOpenLikedAuthor = useCallback((postId: number) => {
     setSelectedPostId(postId);
@@ -88,6 +92,7 @@ export default function PostDetail() {
           onAuthorPress={onOpenLikedAuthor}
         />
       </SafeAreaView>
+
       {isCommentsVisible && (
         <View className="flex-1">
           <CommentsSection
@@ -98,56 +103,58 @@ export default function PostDetail() {
         </View>
       )}
 
-      <View className="flex-1 ">
-        <MotionModal
-          visible={isLikedModalVisible}
-          onClose={() => setIsLikedModalVisible(false)}
-          maxHeight={deviceHeight}
-          initialHeight={deviceHeight * 0.6}
-        >
-          <View className="flex-1 ">
-            <FlatList
-              className="w-full px-4 py-2 "
-              data={likedAuthorData}
-              keyExtractor={(item, index) => `liked-author-${index}`}
-              renderItem={({ item }) => (
-                <TouchableOpacity
-                  onPress={() => {
-                    setIsLikedModalVisible(false);
-                    if (user?.id === item.author?.id) router.push("/mypage");
-                    else router.push(`/user/${item.author?.id}`);
-                  }}
-                  className="w-full flex-1 flex-row items-center gap-2 px-2 py-4"
-                >
-                  <Image
-                    source={
-                      item.author?.avatarUrl
-                        ? { uri: item.author?.avatarUrl }
-                        : images.AvaTarDefault
-                    }
-                    resizeMode="cover"
-                    className="size-10 rounded-full"
-                  />
-                  <Text
-                    className="flex-1 font-psemibold text-[16px] text-gray-90 leading-[150%]"
-                    numberOfLines={1}
-                    ellipsizeMode="tail"
+      {isLikedModalVisible && (
+        <View className="flex-1 ">
+          <MotionModal
+            visible={isLikedModalVisible}
+            onClose={() => setIsLikedModalVisible(false)}
+            maxHeight={deviceHeight}
+            initialHeight={deviceHeight * 0.6}
+          >
+            <View className="flex-1 ">
+              <FlatList
+                className="w-full px-4 py-2 "
+                data={likedAuthorData}
+                keyExtractor={(item, index) => `liked-author-${index}`}
+                renderItem={({ item }) => (
+                  <TouchableOpacity
+                    onPress={() => {
+                      setIsLikedModalVisible(false);
+                      if (user?.id === item.author?.id) router.push("/mypage");
+                      else router.push(`/user/${item.author?.id}`);
+                    }}
+                    className="w-full flex-1 flex-row items-center gap-2 px-2 py-4"
                   >
-                    {item.author?.username}
-                  </Text>
+                    <Image
+                      source={
+                        item.author?.avatarUrl
+                          ? { uri: item.author?.avatarUrl }
+                          : images.AvaTarDefault
+                      }
+                      resizeMode="cover"
+                      className="size-10 rounded-full"
+                    />
+                    <Text
+                      className="flex-1 font-psemibold text-[16px] text-gray-90 leading-[150%]"
+                      numberOfLines={1}
+                      ellipsizeMode="tail"
+                    >
+                      {item.author?.username}
+                    </Text>
 
-                  <Icons.HeartIcon
-                    width={24}
-                    height={24}
-                    color={colors.secondary.red}
-                    fill={colors.secondary.red}
-                  />
-                </TouchableOpacity>
-              )}
-            />
-          </View>
-        </MotionModal>
-      </View>
+                    <Icons.HeartIcon
+                      width={24}
+                      height={24}
+                      color={colors.secondary.red}
+                      fill={colors.secondary.red}
+                    />
+                  </TouchableOpacity>
+                )}
+              />
+            </View>
+          </MotionModal>
+        </View>
+      )}
     </>
   );
 }

--- a/app/post/[postId].tsx
+++ b/app/post/[postId].tsx
@@ -1,0 +1,71 @@
+import { HeaderWithBackAndPostPage } from "@/components/Header";
+import PostItem from "@/components/PostItem";
+import CommentsSection from "@/components/comments/CommentsSection";
+import useFetchData from "@/hooks/useFetchData";
+import { getCurrentUser, getPost } from "@/utils/supabase";
+import { useLocalSearchParams } from "expo-router";
+import { useCallback, useState } from "react";
+import { View } from "react-native";
+
+export default function PostDetail() {
+  const { postId } = useLocalSearchParams();
+  const [isCommentsVisible, setIsCommentsVisible] = useState(false);
+
+  const { data: user } = useFetchData(
+    ["currentUser"],
+    getCurrentUser,
+    "현재 사용자를 불러올 수 없습니다.",
+  );
+
+  const { data: post } = useFetchData(
+    ["post", postId],
+    () => getPost(Number(postId)),
+    "포스트를 불러오는데 실패했습니다.",
+  );
+
+  const onCloseComments = useCallback(() => {
+    setIsCommentsVisible(false);
+  }, []);
+
+  return (
+    <View className="flex-1 bg-white">
+      <HeaderWithBackAndPostPage name={user?.username as string} />
+      <PostItem
+        author={{
+          id: post?.userData?.id || "",
+          name: post?.userData?.username || "",
+          avatar: post?.userData?.avatarUrl || "",
+        }}
+        images={post?.images || []}
+        contents={post?.contents || ""}
+        liked={post?.isLikedByUser || false}
+        likedAuthorAvatars={post?.likedAvatars || []}
+        createdAt={post?.createdAt || ""}
+        commentsCount={post?.totalComments || 0}
+        comment={
+          post?.commentData
+            ? {
+                author: {
+                  name: post.commentData.author.username,
+                  avatar: post.commentData.author.avatarUrl || "",
+                },
+                content: post.commentData.contents,
+              }
+            : null
+        }
+        postId={Number(postId)}
+        onCommentsPress={() => setIsCommentsVisible(true)}
+      />
+
+      {isCommentsVisible && (
+        <View className="flex-1">
+          <CommentsSection
+            visible={isCommentsVisible}
+            onClose={onCloseComments}
+            postId={Number(postId)}
+          />
+        </View>
+      )}
+    </View>
+  );
+}

--- a/app/post/[postId].tsx
+++ b/app/post/[postId].tsx
@@ -6,6 +6,7 @@ import { getCurrentUser, getPost } from "@/utils/supabase";
 import { useLocalSearchParams } from "expo-router";
 import { useCallback, useState } from "react";
 import { View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function PostDetail() {
   const { postId } = useLocalSearchParams();
@@ -28,35 +29,36 @@ export default function PostDetail() {
   }, []);
 
   return (
-    <View className="flex-1 bg-white">
-      <HeaderWithBackAndPostPage name={user?.username as string} />
-      <PostItem
-        author={{
-          id: post?.userData?.id || "",
-          name: post?.userData?.username || "",
-          avatar: post?.userData?.avatarUrl || "",
-        }}
-        images={post?.images || []}
-        contents={post?.contents || ""}
-        liked={post?.isLikedByUser || false}
-        likedAuthorAvatars={post?.likedAvatars || []}
-        createdAt={post?.createdAt || ""}
-        commentsCount={post?.totalComments || 0}
-        comment={
-          post?.commentData
-            ? {
-                author: {
-                  name: post.commentData.author.username,
-                  avatar: post.commentData.author.avatarUrl || "",
-                },
-                content: post.commentData.contents,
-              }
-            : null
-        }
-        postId={Number(postId)}
-        onCommentsPress={() => setIsCommentsVisible(true)}
-      />
-
+    <>
+      <SafeAreaView edges={["top"]} className="flex-1 bg-white">
+        <HeaderWithBackAndPostPage name={post?.userData.username ?? ""} />
+        <PostItem
+          author={{
+            id: post?.userData?.id || "",
+            name: post?.userData?.username || "",
+            avatar: post?.userData?.avatarUrl || "",
+          }}
+          images={post?.images || []}
+          contents={post?.contents || ""}
+          liked={post?.isLikedByUser || false}
+          likedAuthorAvatars={post?.likedAvatars || []}
+          createdAt={post?.createdAt || ""}
+          commentsCount={post?.totalComments || 0}
+          comment={
+            post?.commentData
+              ? {
+                  author: {
+                    name: post.commentData.author.username,
+                    avatar: post.commentData.author.avatarUrl || "",
+                  },
+                  content: post.commentData.contents,
+                }
+              : null
+          }
+          postId={Number(postId)}
+          onCommentsPress={() => setIsCommentsVisible(true)}
+        />
+      </SafeAreaView>
       {isCommentsVisible && (
         <View className="flex-1">
           <CommentsSection
@@ -66,6 +68,6 @@ export default function PostDetail() {
           />
         </View>
       )}
-    </View>
+    </>
   );
 }

--- a/app/post/[postId].tsx
+++ b/app/post/[postId].tsx
@@ -1,4 +1,4 @@
-import { HeaderWithBackAndPostPage } from "@/components/Header";
+import { HeaderWithUsername } from "@/components/Header";
 import MotionModal from "@/components/MotionModal";
 import PostItem from "@/components/PostItem";
 import CommentsSection from "@/components/comments/CommentsSection";
@@ -56,7 +56,10 @@ export default function PostDetail() {
   return (
     <>
       <SafeAreaView edges={["top"]} className="flex-1 bg-white">
-        <HeaderWithBackAndPostPage name={post?.userData.username ?? ""} />
+        <HeaderWithUsername
+          name={post?.userData.username ?? ""}
+          type="POST_PAGE"
+        />
         <PostItem
           author={{
             id: post?.userData?.id || "",

--- a/app/post/[postId].tsx
+++ b/app/post/[postId].tsx
@@ -1,16 +1,26 @@
 import { HeaderWithBackAndPostPage } from "@/components/Header";
+import MotionModal from "@/components/MotionModal";
 import PostItem from "@/components/PostItem";
 import CommentsSection from "@/components/comments/CommentsSection";
+import colors from "@/constants/colors";
+import Icons from "@/constants/icons";
+import images from "@/constants/images";
 import useFetchData from "@/hooks/useFetchData";
-import { getCurrentUser, getPost } from "@/utils/supabase";
-import { useLocalSearchParams } from "expo-router";
+import { getCurrentUser, getPost, getPostLikes } from "@/utils/supabase";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useState } from "react";
-import { View } from "react-native";
+import { FlatList, Image, Text, TouchableOpacity } from "react-native";
+import { Dimensions, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+
+const { height: deviceHeight } = Dimensions.get("window");
 
 export default function PostDetail() {
   const { postId } = useLocalSearchParams();
   const [isCommentsVisible, setIsCommentsVisible] = useState(false);
+  const [isLikedModalVisible, setIsLikedModalVisible] = useState(false);
+  const [selectedPostId, setSelectedPostId] = useState<number | null>(null);
+  const router = useRouter();
 
   const { data: user } = useFetchData(
     ["currentUser"],
@@ -23,6 +33,21 @@ export default function PostDetail() {
     () => getPost(Number(postId)),
     "포스트를 불러오는데 실패했습니다.",
   );
+
+  const { data: likedAuthorData } = useFetchData(
+    ["likedAuthorAvatar", selectedPostId],
+    () => {
+      if (selectedPostId) return getPostLikes(selectedPostId);
+      return Promise.resolve([]);
+    },
+    "좋아요한 사용자 정보를 불러오는데 실패했습니다.",
+    isLikedModalVisible,
+  );
+
+  const onOpenLikedAuthor = useCallback((postId: number) => {
+    setSelectedPostId(postId);
+    setIsLikedModalVisible(true);
+  }, []);
 
   const onCloseComments = useCallback(() => {
     setIsCommentsVisible(false);
@@ -57,6 +82,7 @@ export default function PostDetail() {
           }
           postId={Number(postId)}
           onCommentsPress={() => setIsCommentsVisible(true)}
+          onAuthorPress={onOpenLikedAuthor}
         />
       </SafeAreaView>
       {isCommentsVisible && (
@@ -68,6 +94,57 @@ export default function PostDetail() {
           />
         </View>
       )}
+
+      <View className="flex-1 ">
+        <MotionModal
+          visible={isLikedModalVisible}
+          onClose={() => setIsLikedModalVisible(false)}
+          maxHeight={deviceHeight}
+          initialHeight={deviceHeight * 0.6}
+        >
+          <View className="flex-1 ">
+            <FlatList
+              className="w-full px-4 py-2 "
+              data={likedAuthorData}
+              keyExtractor={(item, index) => `liked-author-${index}`}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  onPress={() => {
+                    setIsLikedModalVisible(false);
+                    if (user?.id === item.author?.id) router.push("/mypage");
+                    else router.push(`/user/${item.author?.id}`);
+                  }}
+                  className="w-full flex-1 flex-row items-center gap-2 px-2 py-4"
+                >
+                  <Image
+                    source={
+                      item.author?.avatarUrl
+                        ? { uri: item.author?.avatarUrl }
+                        : images.AvaTarDefault
+                    }
+                    resizeMode="cover"
+                    className="size-10 rounded-full"
+                  />
+                  <Text
+                    className="flex-1 font-psemibold text-[16px] text-gray-90 leading-[150%]"
+                    numberOfLines={1}
+                    ellipsizeMode="tail"
+                  >
+                    {item.author?.username}
+                  </Text>
+
+                  <Icons.HeartIcon
+                    width={24}
+                    height={24}
+                    color={colors.secondary.red}
+                    fill={colors.secondary.red}
+                  />
+                </TouchableOpacity>
+              )}
+            />
+          </View>
+        </MotionModal>
+      </View>
     </>
   );
 }

--- a/app/user/[userId].tsx
+++ b/app/user/[userId].tsx
@@ -1,4 +1,7 @@
+import { HeaderWithUserPage } from "@/components/Header";
+import CustomModal from "@/components/Modal";
 import colors from "@/constants/colors";
+import Icons from "@/constants/icons";
 import images from "@/constants/images";
 import useFetchData from "@/hooks/useFetchData";
 import {
@@ -8,19 +11,16 @@ import {
   getUser,
 } from "@/utils/supabase";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import { useState } from "react";
 import {
-  View,
-  Text,
-  Image,
-  TouchableOpacity,
   Dimensions,
   FlatList,
+  Image,
+  Text,
+  TouchableOpacity,
+  View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useState } from "react";
-import Icons from "@/constants/icons";
-import CustomModal from "@/components/Modal";
-import { HeaderWithUserPage } from "@/components/Header";
 
 const User = () => {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -92,16 +92,20 @@ const User = () => {
                     style={{ height: size, width: size }}
                     className="bg-gray-5"
                   >
-                    <Image
-                      source={{ uri: item.images[0] }}
-                      resizeMode="cover"
-                      style={{ width: "100%", height: "100%" }}
-                    />
+                    <TouchableOpacity
+                      onPress={() => router.push(`/post/${item.id}`)}
+                    >
+                      <Image
+                        source={{ uri: item.images[0] }}
+                        resizeMode="cover"
+                        style={{ width: "100%", height: "100%" }}
+                      />
+                    </TouchableOpacity>
                   </View>
                 );
               }}
               numColumns={3}
-              keyExtractor={(item) => item.id}
+              keyExtractor={(item) => item.id.toString()}
               className="mt-[32px]"
             />
           ) : (

--- a/app/user/[userId].tsx
+++ b/app/user/[userId].tsx
@@ -1,4 +1,4 @@
-import { HeaderWithUserPage } from "@/components/Header";
+import { HeaderWithUsername } from "@/components/Header";
 import CustomModal from "@/components/Modal";
 import colors from "@/constants/colors";
 import Icons from "@/constants/icons";
@@ -48,7 +48,7 @@ const User = () => {
 
   return (
     <>
-      <HeaderWithUserPage name={user?.username || ""} />
+      <HeaderWithUsername name={user?.username || ""} />
       <SafeAreaView edges={[]} className="flex-1 bg-white">
         <View className="w-full flex-1">
           <View className="mt-6 px-5">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -108,7 +108,12 @@ export function HeaderWithSettingAndNotification({ name }: HeaderProps) {
   );
 }
 
-export function HeaderWithUserPage({ name }: { name: string }) {
+export function HeaderWithUsername({
+  name,
+  type = "MY_PAGE",
+}: { name: string; type?: "MY_PAGE" | "POST_PAGE" }) {
+  const isMyPage = type === "MY_PAGE";
+
   return (
     <SafeAreaView edges={["top"]} className="border-gray-25 border-b bg-white">
       <View className="h-14 flex-row items-center gap-6 px-4">
@@ -127,35 +132,9 @@ export function HeaderWithUserPage({ name }: { name: string }) {
           >
             {name}
           </Text>
-          <Text className="title-2 shrink-0">님의 페이지</Text>
-        </View>
-      </View>
-    </SafeAreaView>
-  );
-}
-
-export function HeaderWithBackAndPostPage({ name }: { name: string }) {
-  return (
-    <SafeAreaView
-      edges={[]}
-      className="border-gray-25 border-b bg-white w-full"
-    >
-      <View className="h-14 flex-row items-center gap-6 px-4 w-full">
-        <TouchableOpacity
-          onPress={() => router.back()}
-          accessibilityLabel="뒤로가기"
-        >
-          <icons.ChevronLeftIcon width={24} height={24} color="#727272" />
-        </TouchableOpacity>
-        <View className="flex-1 flex-row items-center">
-          <Text
-            className="heading-2 flex-shrink"
-            numberOfLines={1}
-            ellipsizeMode="tail"
-          >
-            {name}
+          <Text className="title-2 shrink-0">
+            {isMyPage ? "님의 페이지" : "님의 게시글"}
           </Text>
-          <Text className="heading-2 flex-shrink-0"> 님의 게시글</Text>
         </View>
       </View>
     </SafeAreaView>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -129,13 +129,13 @@ export function HeaderWithUsername({
         </TouchableOpacity>
         <View className="w-[285px] flex-row items-center">
           <Text
-            className="title-2 flex-1"
+            className="title-2 flex-shrink"
             numberOfLines={1}
             ellipsizeMode="tail"
           >
             {name}
           </Text>
-          <Text className="title-2 shrink-0">
+          <Text className="title-2 flex-shrink-0">
             {isMyPage ? "님의 페이지" : "님의 게시글"}
           </Text>
         </View>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -127,20 +127,26 @@ export function HeaderWithUserPage({ name }: { name: string }) {
 
 export function HeaderWithBackAndPostPage({ name }: { name: string }) {
   return (
-    <SafeAreaView edges={[]} className="border-gray-25 border-b bg-white">
-      <View className="h-14 flex-row items-center gap-6 px-4">
+    <SafeAreaView
+      edges={[]}
+      className="border-gray-25 border-b bg-white w-full"
+    >
+      <View className="h-14 flex-row items-center gap-6 px-4 w-full">
         <TouchableOpacity
           onPress={() => router.back()}
           accessibilityLabel="뒤로가기"
-          className=""
         >
           <icons.ChevronLeftIcon width={24} height={24} color="#727272" />
         </TouchableOpacity>
         <View className="flex-1 flex-row items-center">
-          <Text className="heading-2" numberOfLines={1} ellipsizeMode="tail">
+          <Text
+            className="heading-2 flex-shrink"
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
             {name}
           </Text>
-          <Text className="heading-2 shrink-0">님의 게시글</Text>
+          <Text className="heading-2 flex-shrink-0"> 님의 게시글</Text>
         </View>
       </View>
     </SafeAreaView>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,6 +19,7 @@ const HEADER_TITLE = {
   HISTORY: "기록",
   FRIEND: "친구",
   CHANGE_PASSWORD: "비밀번호 변경",
+  POST_DETAIL: "게시물",
 } as const;
 type HeaderType = keyof typeof HEADER_TITLE;
 
@@ -119,6 +120,28 @@ export function HeaderWithUserPage({ name }: { name: string }) {
           <icons.ChevronLeftIcon width={24} height={24} color="#727272" />
         </TouchableOpacity>
         <Text className="heading-2">{name}님의 페이지</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+export function HeaderWithBackAndPostPage({ name }: { name: string }) {
+  return (
+    <SafeAreaView edges={["top"]} className="border-gray-25 border-b bg-white">
+      <View className="h-14 flex-row items-center gap-6 px-4">
+        <TouchableOpacity
+          onPress={() => router.back()}
+          accessibilityLabel="뒤로가기"
+          className=""
+        >
+          <icons.ChevronLeftIcon width={24} height={24} color="#727272" />
+        </TouchableOpacity>
+        <View className="flex-1 flex-row items-center">
+          <Text className="heading-2" numberOfLines={1} ellipsizeMode="tail">
+            {name}
+          </Text>
+          <Text className="heading-2 shrink-0">님의 페이지</Text>
+        </View>
       </View>
     </SafeAreaView>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -127,7 +127,7 @@ export function HeaderWithUserPage({ name }: { name: string }) {
 
 export function HeaderWithBackAndPostPage({ name }: { name: string }) {
   return (
-    <SafeAreaView edges={["top"]} className="border-gray-25 border-b bg-white">
+    <SafeAreaView edges={[]} className="border-gray-25 border-b bg-white">
       <View className="h-14 flex-row items-center gap-6 px-4">
         <TouchableOpacity
           onPress={() => router.back()}
@@ -140,7 +140,7 @@ export function HeaderWithBackAndPostPage({ name }: { name: string }) {
           <Text className="heading-2" numberOfLines={1} ellipsizeMode="tail">
             {name}
           </Text>
-          <Text className="heading-2 shrink-0">님의 페이지</Text>
+          <Text className="heading-2 shrink-0">님의 게시글</Text>
         </View>
       </View>
     </SafeAreaView>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -115,7 +115,10 @@ export function HeaderWithUsername({
   const isMyPage = type === "MY_PAGE";
 
   return (
-    <SafeAreaView edges={["top"]} className="border-gray-25 border-b bg-white">
+    <SafeAreaView
+      edges={isMyPage ? ["top"] : []}
+      className="border-gray-25 border-b bg-white"
+    >
       <View className="h-14 flex-row items-center gap-6 px-4">
         <TouchableOpacity
           onPress={() => router.back()}

--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -104,7 +104,9 @@ export default function PostItem({
           >
             <View className="h-14 flex-row items-center gap-2">
               <Image
-                source={{ uri: author.avatar }}
+                source={
+                  author.avatar ? { uri: author.avatar } : imgs.AvaTarDefault
+                }
                 resizeMode="cover"
                 className="size-8 rounded-full"
               />

--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -101,7 +101,7 @@ export default function PostItem({
       <View className="grow bg-white ">
         {/* header */}
         <View className="flex-row items-center justify-between bg-white px-4">
-          <TouchableOpacity onPress={() => router.push(`/user/${author.id}`)}>
+          <TouchableOpacity>
             <View className="h-14 flex-row items-center gap-2">
               <Image
                 source={{ uri: author.avatar }}

--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -26,7 +26,7 @@ interface PostItemProps {
   images: string[];
   contents?: string | null;
   liked: boolean;
-  likedAuthorAvatar?: string[];
+  likedAuthorAvatars?: string[];
   createdAt: string;
   commentsCount?: number;
   comment?: {
@@ -45,7 +45,7 @@ export default function PostItem({
   images,
   contents,
   liked,
-  likedAuthorAvatar,
+  likedAuthorAvatars,
   createdAt,
   commentsCount = 0,
   comment,
@@ -101,7 +101,7 @@ export default function PostItem({
       <View className="grow bg-white ">
         {/* header */}
         <View className="flex-row items-center justify-between bg-white px-4">
-          <TouchableOpacity>
+          <TouchableOpacity onPress={() => router.push(`/user/${author.id}`)}>
             <View className="h-14 flex-row items-center gap-2">
               <Image
                 source={{ uri: author.avatar }}
@@ -185,9 +185,9 @@ export default function PostItem({
             </TouchableOpacity>
 
             {/* likeAvatar */}
-            {likedAuthorAvatar && likedAuthorAvatar.length > 0 && (
+            {likedAuthorAvatars && likedAuthorAvatars.length > 0 && (
               <TouchableOpacity className="ml-[2px] flex-row items-center">
-                {likedAuthorAvatar.slice(0, 2).map((avatar, index) => (
+                {likedAuthorAvatars.slice(0, 2).map((avatar, index) => (
                   <Image
                     // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
                     key={`avatar-${index}`}
@@ -201,7 +201,7 @@ export default function PostItem({
                     }}
                   />
                 ))}
-                {likedAuthorAvatar.length > 2 && (
+                {likedAuthorAvatars.length > 2 && (
                   <Text className="pl-[2px] font-psemibold text-[13px] text-gray-90 leading-[150%]">
                     외 여러명
                   </Text>

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -207,7 +207,7 @@ export default function CommentItem({
                 <Image
                   // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
                   key={`avatar-${index}`}
-                  source={{ uri: avatar }}
+                  source={avatar ? { uri: avatar } : images.AvaTarDefault}
                   resizeMode="cover"
                   className={`size-[24px] rounded-full border border-white ${index !== 0 ? "-ml-[9px]" : ""}`}
                   style={{

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -261,6 +261,41 @@ export type Database = {
           },
         ];
       };
+      pushToken: {
+        Row: {
+          createdAt: string;
+          deviceId: string;
+          grantedNotifications: Database["public"]["Enums"]["notificationtype"][];
+          id: number;
+          pushToken: string;
+          userId: string;
+        };
+        Insert: {
+          createdAt?: string;
+          deviceId: string;
+          grantedNotifications: Database["public"]["Enums"]["notificationtype"][];
+          id?: number;
+          pushToken: string;
+          userId: string;
+        };
+        Update: {
+          createdAt?: string;
+          deviceId?: string;
+          grantedNotifications?: Database["public"]["Enums"]["notificationtype"][];
+          id?: number;
+          pushToken?: string;
+          userId?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "pushToken_userId_fkey";
+            columns: ["userId"];
+            isOneToOne: false;
+            referencedRelation: "user";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       user: {
         Row: {
           avatarUrl: string | null;
@@ -357,12 +392,41 @@ export type Database = {
             avatarUrl: string | null;
           };
           likes: number;
-          parentsCommentId: number | null;
-          replyCommentId: number | null;
           isLiked: boolean;
           likedAvatars: string[];
+          parentsCommentId: number;
           totalReplies: number;
         }[];
+      };
+      get_post_with_details: {
+        Args: {
+          postId: number;
+        };
+        Returns: {
+          id: number;
+          images: string[];
+          contents: string;
+          createdAt: string;
+          userData: {
+            id: string;
+            username: string;
+            avatarUrl: string | null;
+          };
+          commentData: {
+            id: number;
+            contents: string;
+            createdAt: string;
+            userId: string;
+            author: {
+              id: string;
+              username: string;
+              avatarUrl: string | null;
+            };
+          };
+          totalComments: number;
+          likedAvatars: string[];
+          isLikedByUser: boolean;
+        };
       };
       get_posts_with_details: {
         Args: {

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -394,73 +394,16 @@ export const getPosts = async ({ page = 0, limit = 10 }) => {
 // 게시글 상세 조회
 export async function getPost(postId: number) {
   try {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
+    const { data, error } = await supabase.rpc("get_post_with_details", {
+      postId,
+    });
 
-    const { data: post, error: postError } = await supabase
-      .from("post")
-      .select(
-        `
-        id,
-        images,
-        contents,
-        likes,
-        createdAt,
-        user (id, username, avatarUrl)
-      `,
-      )
-      .eq("id", postId)
-      .single();
+    if (error) throw new Error("게시글을 가져오는데 실패했습니다.");
 
-    if (postError) throw postError;
-    if (!post) throw new Error("게시글을 찾을 수 없습니다.");
-
-    const {
-      data: comment,
-      error: commentError,
-      count,
-    } = await supabase
-      .from("comment")
-      .select("id, contents, likes, author:user (id, username, avatarUrl)", {
-        count: "exact",
-      })
-      .eq("postId", postId)
-      .order("likes", { ascending: false })
-      .order("createdAt", { ascending: false })
-      .single();
-
-    if (commentError && commentError.code !== "PGRST116") {
-      // 댓글이 없는 경우 오류 처리
-      throw commentError;
-    }
-
-    let isLiked = false;
-
-    if (user) {
-      // postLike 테이블에서 좋아요 여부 확인
-      const { data: likeData, error: likeError } = await supabase
-        .from("postLike")
-        .select("id")
-        .eq("postId", postId)
-        .eq("userId", user.id)
-        .single();
-
-      if (likeError && likeError.code !== "PGRST116") {
-        throw likeError;
-      }
-      isLiked = !!likeData; // 좋아요 데이터가 존재하면 true
-    }
-
-    return {
-      ...post,
-      comment: { ...comment, totalComments: count },
-      isLiked,
-    };
+    return data;
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : "게시글 조회에 실패했습니다";
-    throw new Error(errorMessage);
+    console.error("Error in getPost:", error);
+    throw new Error("게시글을 가져오는데 실패했습니다.");
   }
 }
 


### PR DESCRIPTION
## 📝 PR 설명
게시글 상세보기 페이지 제작했습니다
사용자 프로필에서 이미지 터치하면 바로 이동되게 해뒀습니다
페이지 들어갔을때 warning 나올수도 있는데 이미지 오류라 다른 브랜치에서 해결된 문제입니다
![image](https://github.com/user-attachments/assets/1b7f5392-0a73-4ec5-adb2-6b406a89aa52)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 사용자 프로필 및 게시물 세부 정보를 표시하는 `PostDetail` 컴포넌트 추가.
  - 게시물 상세 페이지로의 네비게이션을 지원하는 `HeaderWithUsername` 컴포넌트 추가.
  - `MyPage` 컴포넌트에서 이미지 클릭 시 게시물 상세 페이지로 이동 가능.
  - `Home` 컴포넌트에서 좋아하는 작성자 아바타의 prop 이름 변경으로 일관성 향상.

- **버그 수정**
  - `PostItem` 컴포넌트의 prop 이름 변경으로 인한 일관성 향상.

- **개선 사항**
  - 데이터 가져오기 로직 개선으로 `getPost` 함수의 효율성 향상.
  - 사용자 데이터 및 게시물 로딩 상태 관리 개선.
  - 모달 기능을 통해 사용자 상호작용 향상.
  - `MyPage` 컴포넌트의 사용자 데이터 렌더링 로직 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->