### PR TITLE
fix: 답글 멘션 기능 수정

### DIFF
--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -34,6 +34,10 @@ export function NotificationItem({
     [NOTIFICATION_TYPE.LIKE]: {
       title: [`${from.username}님이`, "게시글에 좋아요를 눌렀어요❤️"],
     },
+    [NOTIFICATION_TYPE.MENTION]: {
+      title: `${from.username}님이 회원님을 언급했어요`,
+      content: shorten_comment(data?.commentInfo?.content || ""),
+    },
   };
 
   const diff = diffDate(new Date(createdAt));

--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -107,6 +107,7 @@ export default function PostItem({
         from: user.data?.id || "",
         to: author.id,
         type: "like",
+        data: { postId },
       }),
   });
 

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -43,7 +43,11 @@ interface CommentItemProps {
   likedAvatars: string[];
   createdAt: string;
   parentsCommentId?: number;
-  replyCommentId?: number;
+  replyTo?: {
+    id: string;
+    username: string;
+    avatarUrl: string | null;
+  };
   totalReplies?: number;
   onReply: (
     userId: string,
@@ -65,7 +69,7 @@ export default function CommentItem({
   likedAvatars = [],
   createdAt,
   parentsCommentId,
-  replyCommentId,
+  replyTo,
   totalReplies,
   onReply,
   isReply = false,
@@ -126,6 +130,7 @@ export default function CommentItem({
       }
 
       queryClient.invalidateQueries({ queryKey: ["comments", postId] });
+      queryClient.invalidateQueries({ queryKey: ["replies"] });
     },
     onError: () => {
       setIsLiked((prev) => !prev);
@@ -290,6 +295,9 @@ export default function CommentItem({
           }
           className="title-5 flex-1 text-gray-90"
         >
+          {isReply && replyTo?.username && (
+            <Text className="title-5 text-primary">@{replyTo.username} </Text>
+          )}
           {isTextMore ? contents : truncateText(contents)}
           {contents.length > calculateMaxChars && (
             <Text className="title-5 -mb-[3px] text-gray-45">
@@ -332,7 +340,7 @@ export default function CommentItem({
                   likedAvatars={item.likedAvatars}
                   createdAt={item.createdAt}
                   parentsCommentId={item.parentsCommentId}
-                  replyCommentId={item.replyCommentId}
+                  replyTo={item.replyTo}
                   onReply={onReply}
                   isReply={true}
                   onCommentsClose={onCommentsClose}

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -143,6 +143,12 @@ export default function CommentItem({
         from: user.data?.id || "",
         to: author?.id || "",
         type: "commentLike",
+        data: {
+          postId,
+          commentInfo: {
+            id,
+          },
+        },
       }),
   });
 

--- a/components/comments/CommentsSection.tsx
+++ b/components/comments/CommentsSection.tsx
@@ -135,7 +135,10 @@ export default function CommentsSection({
 
       const replyToId = replyTo?.userId || authorId;
       if (replyToId !== user.data?.id) {
-        sendNotificationMutation.mutate({ commentId: data.id });
+        sendNotificationMutation.mutate({
+          commentId: data.id,
+          type: replyToId === authorId ? "comment" : "mention",
+        });
       }
 
       setComment("");
@@ -151,11 +154,14 @@ export default function CommentsSection({
   });
 
   const sendNotificationMutation = useMutation({
-    mutationFn: ({ commentId }: { commentId: number }) =>
+    mutationFn: ({
+      commentId,
+      type = "comment",
+    }: { commentId: number; type?: "comment" | "mention" }) =>
       createNotification({
         from: user.data?.id || "",
         to: replyTo?.userId || authorId || "",
-        type: "comment",
+        type: type,
         data: {
           postId,
           commentInfo: {

--- a/components/comments/CommentsSection.tsx
+++ b/components/comments/CommentsSection.tsx
@@ -305,7 +305,9 @@ export default function CommentsSection({
           <View className="relative h-[40px] w-full flex-row items-center bg-gray-20">
             <Text className="w-full flex-1 items-center justify-center text-center font-pmedium text-[14px] text-gray-60 leading-[150%]">
               <Text className="font-pmedium text-[#000] text-[14px] leading-[150%]">
-                {replyTo.username}
+                {replyTo.username.length > 20
+                  ? `${replyTo.username.slice(0, 20)}...`
+                  : replyTo.username}
               </Text>
               님께 답글 달기
             </Text>
@@ -340,7 +342,7 @@ export default function CommentsSection({
             }}
             placeholder={
               replyTo
-                ? `${replyTo.username}님에게 답글`
+                ? `${replyTo.username.length > 10 ? `${replyTo.username.slice(0, 10)}...` : replyTo.username}님께 답글을 남겨보세요.`
                 : "댓글을 입력해주세요."
             }
             onSubmit={() => {

--- a/components/comments/CommentsSection.tsx
+++ b/components/comments/CommentsSection.tsx
@@ -36,7 +36,7 @@ import { ToastConfig, showToast } from "../ToastConfig";
 import CommentItem from "./CommentItem";
 import MentionInput from "./MentionInput";
 
-const { height: deviceHeight } = Dimensions.get("window");
+const { height: deviceHeight, width: deviceWidth } = Dimensions.get("window");
 
 interface CommentsSectionProps {
   visible: boolean;
@@ -302,15 +302,23 @@ export default function CommentsSection({
       {/* comment input */}
       <>
         {replyTo?.username && (
-          <View className="relative h-[40px] w-full flex-row items-center bg-gray-20">
-            <Text className="w-full flex-1 items-center justify-center text-center font-pmedium text-[14px] text-gray-60 leading-[150%]">
-              <Text className="font-pmedium text-[#000] text-[14px] leading-[150%]">
-                {replyTo.username.length > 20
-                  ? `${replyTo.username.slice(0, 20)}...`
-                  : replyTo.username}
+          <View className="relative h-[40px] w-full flex-row items-center justify-center bg-gray-20">
+            <View
+              className="flex-row items-center justify-center text-center"
+              style={{ width: "70%" }}
+            >
+              <Text
+                className="shrink font-pmedium text-[#000] text-[14px] leading-[150%]"
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {replyTo.username}
               </Text>
-              님께 답글 달기
-            </Text>
+
+              <Text className="shrink-0 font-pmedium text-[14px] text-gray-60 leading-[150%]">
+                님께 답글 달기
+              </Text>
+            </View>
 
             <TouchableOpacity
               className="-translate-y-1/2 absolute top-1/2 right-5"

--- a/components/comments/CommentsSection.tsx
+++ b/components/comments/CommentsSection.tsx
@@ -300,38 +300,58 @@ export default function CommentsSection({
       </MotionModal>
 
       {/* comment input */}
-      <View
-        className={`z-10 h-20 flex-row items-center gap-4 bg-white px-[18px] pt-4 ${Platform.OS === "ios" ? "pb-8" : "pb-4"}`}
-      >
-        <Image
-          source={
-            user.data?.avatarUrl
-              ? { uri: user.data.avatarUrl }
-              : images.AvaTarDefault
-          }
-          resizeMode="cover"
-          className="size-12 rounded-full"
-        />
+      <>
+        {replyTo?.username && (
+          <View className="relative h-[40px] w-full flex-row items-center bg-gray-20">
+            <Text className="w-full flex-1 items-center justify-center text-center font-pmedium text-[14px] text-gray-60 leading-[150%]">
+              <Text className="font-pmedium text-[#000] text-[14px] leading-[150%]">
+                {replyTo.username}
+              </Text>
+              님께 답글 달기
+            </Text>
 
-        <MentionInput
-          ref={inputRef}
-          value={comment}
-          onChangeText={(text) => {
-            setComment(text);
-          }}
-          setReplyTo={setReplyTo}
-          placeholder={
-            replyTo ? `${replyTo.username}님에게 답글` : "댓글을 입력해주세요."
-          }
-          mentionUser={replyTo}
-          onSubmit={() => {
-            if (comment.trim() && !writeCommentMutation.isPending) {
-              writeCommentMutation.mutate();
+            <TouchableOpacity
+              className="-translate-y-1/2 absolute top-1/2 right-5"
+              onPress={() => setReplyTo(null)}
+            >
+              <Icons.XIcon width={16} height={16} color={colors.gray[90]} />
+            </TouchableOpacity>
+          </View>
+        )}
+
+        <View
+          className={`z-10 h-20 flex-row items-center gap-4 bg-white px-[18px] pt-4 ${Platform.OS === "ios" ? "pb-8" : "pb-4"}`}
+        >
+          <Image
+            source={
+              user.data?.avatarUrl
+                ? { uri: user.data.avatarUrl }
+                : images.AvaTarDefault
             }
-          }}
-          isPending={writeCommentMutation.isPending}
-        />
-      </View>
+            resizeMode="cover"
+            className="size-12 rounded-full"
+          />
+
+          <MentionInput
+            ref={inputRef}
+            value={comment}
+            onChangeText={(text) => {
+              setComment(text);
+            }}
+            placeholder={
+              replyTo
+                ? `${replyTo.username}님에게 답글`
+                : "댓글을 입력해주세요."
+            }
+            onSubmit={() => {
+              if (comment.trim() && !writeCommentMutation.isPending) {
+                writeCommentMutation.mutate();
+              }
+            }}
+            isPending={writeCommentMutation.isPending}
+          />
+        </View>
+      </>
       <Toast config={ToastConfig} />
     </MotionModal>
   );

--- a/components/comments/MentionInput.tsx
+++ b/components/comments/MentionInput.tsx
@@ -1,59 +1,16 @@
-import { forwardRef, useEffect, useState } from "react";
-import { Text, TextInput, View } from "react-native";
+import { forwardRef } from "react";
+import { TextInput, View } from "react-native";
 
 interface MentionInputProps {
   value: string;
   onChangeText: (text: string) => void;
-  setReplyTo: (
-    replyTo: {
-      userId: string;
-      username: string;
-      parentId: number;
-      replyCommentId: number;
-    } | null,
-  ) => void;
   placeholder?: string;
-  mentionUser?: { username: string } | null;
   onSubmit?: () => void;
   isPending?: boolean;
 }
 
 const MentionInput = forwardRef<TextInput, MentionInputProps>(
-  (
-    {
-      value,
-      onChangeText,
-      setReplyTo,
-      placeholder,
-      mentionUser,
-      onSubmit,
-      isPending,
-    },
-    ref,
-  ) => {
-    const mentionText = mentionUser ? `@${mentionUser.username} ` : "";
-    const [inputValue, setInputValue] = useState(mentionText + value);
-
-    const handleChangeText = (text: string) => {
-      if (text.startsWith(mentionText)) {
-        const newText = text.slice(mentionText.length);
-        setInputValue(text);
-        onChangeText(newText);
-      } else {
-        onChangeText(text);
-        if (mentionUser) {
-          setReplyTo(null);
-        }
-      }
-    };
-
-    // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
-    useEffect(() => {
-      if (mentionUser && !inputValue.startsWith(mentionText)) {
-        setInputValue(mentionText + value);
-      }
-    }, [mentionUser, mentionText]);
-
+  ({ value, onChangeText, placeholder, onSubmit, isPending }, ref) => {
     return (
       <View className="flex-1 flex-row items-center">
         <View
@@ -66,13 +23,12 @@ const MentionInput = forwardRef<TextInput, MentionInputProps>(
             autoCapitalize="none"
             keyboardType="default"
             textAlignVertical="center"
-            value={inputValue}
-            onChangeText={handleChangeText}
+            value={value}
+            onChangeText={onChangeText}
             returnKeyType="send"
             onSubmitEditing={() => {
               if (value.trim() && !isPending && onSubmit) {
                 onSubmit();
-                setInputValue("");
               }
             }}
             placeholder={placeholder}
@@ -80,11 +36,6 @@ const MentionInput = forwardRef<TextInput, MentionInputProps>(
               flex: 1,
             }}
           />
-          {mentionText ? (
-            <Text className="absolute bg-white pl-[11.5px] font-pmedium text-[16px] text-primary leading-[150%]">
-              {mentionText}
-            </Text>
-          ) : null}
         </View>
       </View>
     );

--- a/components/comments/MentionInput.tsx
+++ b/components/comments/MentionInput.tsx
@@ -32,9 +32,7 @@ const MentionInput = forwardRef<TextInput, MentionInputProps>(
               }
             }}
             placeholder={placeholder}
-            style={{
-              flex: 1,
-            }}
+            multiline={false}
           />
         </View>
       </View>

--- a/hooks/useTruncateText.ts
+++ b/hooks/useTruncateText.ts
@@ -18,10 +18,7 @@ export const useTruncateText = () => {
 
       let result: string;
       if (lastSentence?.length) {
-        result = truncated.slice(
-          0,
-          truncated.lastIndexOf(lastSentence[lastSentence.length - 1]) + 1,
-        );
+        result = lastSentence[0].replace(/[.!?]+$/, "");
       } else {
         const lastSpace = truncated.lastIndexOf(" ");
         result = lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated;

--- a/types/Notification.interface.ts
+++ b/types/Notification.interface.ts
@@ -5,6 +5,7 @@ export const NOTIFICATION_TYPE = {
   COMMENT: "comment",
   COMMENT_LIKE: "commentLike",
   LIKE: "like",
+  MENTION: "mention",
 } as const;
 export type NotificationType =
   (typeof NOTIFICATION_TYPE)[keyof typeof NOTIFICATION_TYPE];

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -480,6 +480,11 @@ export type Database = {
           createdAt: string;
           parentsCommentId: number;
           replyCommentId: number;
+          replyTo: {
+            id: string;
+            username: string;
+            avatarUrl: string | null;
+          };
           userData: {
             id: string;
             username: string;
@@ -498,7 +503,7 @@ export type Database = {
       };
     };
     Enums: {
-      notificationtype: "poke" | "comment" | "like" | "commentLike";
+      notificationtype: "poke" | "comment" | "like" | "commentLike" | "mention";
       workoutstatus: "done" | "rest";
     };
     CompositeTypes: {


### PR DESCRIPTION
## 📝 PR 설명
기존 멘션 인풋창에 문제가 많아서 새로운 디자인으로 수정했습니다.
추가적으로 답글에 멘션대상이 누구인지 알 수 있게 추가했습니다.
> @정민재 안녕하세요

## 🔍 변경사항
- 인풋창 멘션 제거 후 인풋창 상단에 추가
- 답글의 경우 답글 대상이 멘션으로 댓글 앞에 붙음

## 📸 스크린샷
![KakaoTalk_20241211_174752166](https://github.com/user-attachments/assets/1c385a3e-4644-4f9b-b890-15325a86ceda)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 댓글 컴포넌트에서 사용자에게 답글을 다는 기능 개선.
	- 답글을 다는 사용자 정보를 명확히 표시하는 UI 요소 추가.
	- 댓글 입력 영역의 구조 개선 및 사용자에게 답글 맥락을 명확히 전달하는 텍스트 업데이트.
	- 알림 유형에 '언급' 추가.
	- 알림에 특정 게시물과 연관된 기능 추가.
- **버그 수정**
	- 댓글 좋아요 및 삭제 후 댓글 목록 갱신 로직 개선.
- **문서화**
	- 댓글 및 알림 관련 데이터 구조 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->