### PR TITLE
fix: 멘션 알림 추가, 알림 클릭 시 포스트로 이동

### DIFF
--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -28,6 +28,10 @@ export function NotificationItem({
       title: `${from.username}님의 댓글`,
       content: shorten_comment(data?.commentInfo?.content || ""),
     },
+    [NOTIFICATION_TYPE.MENTION]: {
+      title: `${from.username}님의 멘션`,
+      content: shorten_comment(data?.commentInfo?.content || ""),
+    },
     [NOTIFICATION_TYPE.COMMENT_LIKE]: {
       title: [`${from.username}님이`, "댓글에 좋아요를 눌렀어요❤️"],
     },

--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -1,4 +1,4 @@
-import { Image, Text, View } from "react-native";
+import { Image, Text, TouchableWithoutFeedback, View } from "react-native";
 
 import images from "@/constants/images";
 import {
@@ -6,6 +6,7 @@ import {
   type NotificationResponse,
 } from "@/types/Notification.interface";
 import { diffDate } from "@/utils/formatDate";
+import { router } from "expo-router";
 
 const COMMENT_MAX_LENGTH = 18;
 const shorten_comment = (comment: string) =>
@@ -43,39 +44,43 @@ export function NotificationItem({
   const diff = diffDate(new Date(createdAt));
 
   return (
-    <View className="w-full py-4 border-b border-gray-25 flex-row justify-between items-center">
-      <View className="flex-row gap-4">
-        <Image
-          source={
-            from.avatarUrl ? { uri: from.avatarUrl } : images.AvaTarDefault
-          }
-          style={{ width: 48, height: 48, borderRadius: 9999 }}
-        />
+    <TouchableWithoutFeedback
+      onPress={() => data?.postId && router.push(`/post/${data?.postId}`)}
+    >
+      <View className="w-full py-4 border-b border-gray-25 flex-row justify-between items-center">
+        <View className="flex-row gap-4">
+          <Image
+            source={
+              from.avatarUrl ? { uri: from.avatarUrl } : images.AvaTarDefault
+            }
+            style={{ width: 48, height: 48, borderRadius: 9999 }}
+          />
 
-        <View className="gap-[4px] w-[198px]">
-          {type === "like" || type === "commentLike" ? (
-            <>
-              <Text className="title-4 text-gray-90" numberOfLines={1}>
-                {NOTIFICATION_CONFIG[type].title[0]}
-              </Text>
-              <Text className="title-4 text-gray-90" numberOfLines={1}>
-                {NOTIFICATION_CONFIG[type].title[1]}
-              </Text>
-            </>
-          ) : (
-            <>
-              <Text className="title-4 text-gray-90" numberOfLines={1}>
-                {NOTIFICATION_CONFIG[type].title}
-              </Text>
-              <Text className="body-5 text-gray-45" numberOfLines={1}>
-                {NOTIFICATION_CONFIG[type].content}
-              </Text>
-            </>
-          )}
+          <View className="gap-[4px] w-[198px]">
+            {type === "like" || type === "commentLike" ? (
+              <>
+                <Text className="title-4 text-gray-90" numberOfLines={1}>
+                  {NOTIFICATION_CONFIG[type].title[0]}
+                </Text>
+                <Text className="title-4 text-gray-90" numberOfLines={1}>
+                  {NOTIFICATION_CONFIG[type].title[1]}
+                </Text>
+              </>
+            ) : (
+              <>
+                <Text className="title-4 text-gray-90" numberOfLines={1}>
+                  {NOTIFICATION_CONFIG[type].title}
+                </Text>
+                <Text className="body-5 text-gray-45" numberOfLines={1}>
+                  {NOTIFICATION_CONFIG[type].content}
+                </Text>
+              </>
+            )}
+          </View>
         </View>
-      </View>
 
-      <Text className="caption-3 font-pmedium text-gray-50">{diff}</Text>
-    </View>
+        <Text className="caption-3 font-pmedium text-gray-50">{diff}</Text>
+      </View>
+    </TouchableWithoutFeedback>
   );
 }

--- a/types/Notification.interface.ts
+++ b/types/Notification.interface.ts
@@ -5,6 +5,7 @@ export const NOTIFICATION_TYPE = {
   COMMENT: "comment",
   COMMENT_LIKE: "commentLike",
   LIKE: "like",
+  MENTION: "mention",
 } as const;
 export type NotificationType =
   (typeof NOTIFICATION_TYPE)[keyof typeof NOTIFICATION_TYPE];

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -498,7 +498,7 @@ export type Database = {
       };
     };
     Enums: {
-      notificationtype: "poke" | "comment" | "like" | "commentLike";
+      notificationtype: "poke" | "comment" | "like" | "commentLike" | "mention";
       workoutstatus: "done" | "rest";
     };
     CompositeTypes: {


### PR DESCRIPTION
## 📝 PR 설명
- 멘션 알림 추가
- 포스트 관련 알림 (좋아요, 댓글, 댓글 좋아요, 멘션) 클릭 시 해당 포스트 상세페이지로 이동

댓글, 댓글 좋아요, 멘션 클릭 시 해당 댓글로 갈 수 있는 방법이 있다면 그것도 추가하겠습니다.
(@wjsdncl 가능할까요??)

+) DB notification에서 type과 data 관련 제약사항 추가했습니다.
|type|data|
|-|-|
|poke|null|
|like|{postId: ??}|
|comment, commentLike, mention| {postId: ??, commentId: ??}|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 알림 시스템에 새로운 알림 유형인 `MENTION` 추가.
	- 사용자가 알림을 클릭하여 해당 게시물로 이동할 수 있는 인터랙티브한 알림 항목 제공.

- **버그 수정**
	- 기존 알림 유형에 대한 변경 없이 새로운 알림 유형 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->