### PR TITLE
fix: 게시글 무한스크롤 오류 수정 및 게시글 목록 좌우로 흔들리는 문제 해결

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -146,7 +146,11 @@ export default function Home() {
         }
         ListFooterComponent={
           isFetchingNextPage ? (
-            <ActivityIndicator size="large" className="py-4" />
+            <ActivityIndicator
+              size="large"
+              className="py-4"
+              color={colors.primary}
+            />
           ) : null
         }
         showsVerticalScrollIndicator={false}

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -14,11 +14,11 @@ import {
   FlatList,
   Image,
   RefreshControl,
-  SafeAreaView,
   Text,
   TouchableOpacity,
 } from "react-native";
 import { View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import PostItem from "../../components/PostItem";
 
 const { height: deviceHeight } = Dimensions.get("window");
@@ -101,7 +101,10 @@ export default function Home() {
   }, [refetch]);
 
   return (
-    <SafeAreaView className="flex-1 items-center justify-center bg-white">
+    <SafeAreaView
+      edges={[]}
+      className="flex-1 items-center justify-center bg-white"
+    >
       <FlatList
         data={data?.pages.flatMap((page) => page.posts) ?? []}
         keyExtractor={(item) => item.id.toString()}
@@ -147,7 +150,6 @@ export default function Home() {
           ) : null
         }
         showsVerticalScrollIndicator={false}
-        showsHorizontalScrollIndicator={false}
       />
 
       {isCommentsVisible &&

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -341,7 +341,7 @@ export default function CommentItem({
               )}
               ListFooterComponent={() =>
                 isReplyFetchingNextPage ? (
-                  <ActivityIndicator size="small" />
+                  <ActivityIndicator size="small" color={colors.primary} />
                 ) : null
               }
             />

--- a/components/comments/CommentsSection.tsx
+++ b/components/comments/CommentsSection.tsx
@@ -236,7 +236,11 @@ export default function CommentsSection({
           )}
           ListFooterComponent={
             isFetchingNextPage ? (
-              <ActivityIndicator size="large" className="py-4" />
+              <ActivityIndicator
+                size="large"
+                className="py-4"
+                color={colors.primary}
+              />
             ) : null
           }
           showsVerticalScrollIndicator={false}

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -382,13 +382,14 @@ export async function uploadImage(file: ImagePicker.ImagePickerAsset) {
 // 게시글 조회
 export const getPosts = async ({ page = 0, limit = 10 }) => {
   try {
-    const { data, error, count } = await supabase.rpc(
-      "get_posts_with_details",
-      {
-        startindex: page * limit,
-        endindex: (page + 1) * limit - 1,
-      },
-    );
+    const { count, error: countError } = await supabase
+      .from("post")
+      .select("*", { count: "exact", head: true });
+
+    const { data, error } = await supabase.rpc("get_posts_with_details", {
+      startindex: page * limit,
+      endindex: (page + 1) * limit - 1,
+    });
 
     if (error) throw new Error("게시글을 가져오는데 실패했습니다.");
 


### PR DESCRIPTION
## 📝 PR 설명
게시글 무한 스크롤 기능이 동작하지 않는 문제가 있었습니다.

원인을 확인해보니, 이전에 DB 쿼리를 수정하면서 클라이언트에서 전체 게시글 수(count)를 따로 받아와야 했으나, 이를 처리하지 않아 전체 크기를 알 수 없었던 것이 원인이었습니다. 이로 인해 초기 로드 한 번만 작동하는 문제가 발생했습니다.

지금은 count를 따로 받아와서 문제없이 동작합니다.

아이폰에서 게시글 목록을 잡고 좌우로 흔들 수 있던데 이유 일거 같은거 하나 처리했는데 여전히 그러는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `ActivityIndicator`의 색상을 애플리케이션의 기본 색상으로 업데이트하여 시각적 일관성을 향상시켰습니다.
- **버그 수정**
	- `FlatList`의 `showsHorizontalScrollIndicator` 속성을 제거했습니다.
- **문서화**
	- `SafeAreaView`의 가져오기 경로를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->