### PR TITLE
fix: 유저 삭제 변경 및 기본 아바타 변경

### DIFF
--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -130,19 +130,19 @@ export default function Setting() {
             <TouchableOpacity
               className="h-[52px] w-[127px] items-center justify-center rounded-[10px] bg-primary"
               onPress={async () => {
-                try {
-                  setIsLoading(true);
+                setIsLoading(true);
 
+                try {
                   await deleteUser(currentUser?.id ?? "");
 
                   router.replace("/sign-in");
                   showToast("success", "탈퇴가 완료되었습니다!");
                 } catch (error) {
                   showToast("error", "탈퇴에 실패했습니다.");
-                } finally {
-                  setIsDeleteModalVisible(false);
-                  setIsLoading(false);
                 }
+
+                setIsDeleteModalVisible(false);
+                setIsLoading(false);
               }}
               disabled={isLoading}
             >

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -130,16 +130,19 @@ export default function Setting() {
             <TouchableOpacity
               className="h-[52px] w-[127px] items-center justify-center rounded-[10px] bg-primary"
               onPress={async () => {
-                setIsLoading(true);
+                try {
+                  setIsLoading(true);
 
-                await deleteUser(currentUser?.id ?? "");
+                  await deleteUser(currentUser?.id ?? "");
 
-                setIsDeleteModalVisible(false);
-                setIsLoading(false);
-
-                router.replace("/sign-in");
-
-                showToast("success", "탈퇴가 완료되었습니다!");
+                  router.replace("/sign-in");
+                  showToast("success", "탈퇴가 완료되었습니다!");
+                } catch (error) {
+                  showToast("error", "탈퇴에 실패했습니다.");
+                } finally {
+                  setIsDeleteModalVisible(false);
+                  setIsLoading(false);
+                }
               }}
               disabled={isLoading}
             >

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -68,7 +68,7 @@ export async function signUp({
           id,
           email,
           username,
-          avatarUrl: `https://ui-avatars.com/api/?name=${encodeURIComponent(username)}`,
+          avatarUrl: DEFAULT_AVATAR_URL,
           description: description || null,
           isOAuth: false,
         },
@@ -281,6 +281,14 @@ export async function updateNotificationCheck(userId: string) {
 // 유저 데이터베이스 삭제 (Edge function)
 export async function deleteUser(userId: string) {
   try {
+    const { error: dbError } = await supabase.rpc("delete_user_data", {
+      user_id: userId,
+    });
+
+    if (dbError) {
+      throw dbError;
+    }
+
     const response = await fetch(`${supabaseUrl}/functions/v1/delete-user`, {
       method: "POST",
       headers: {
@@ -294,37 +302,6 @@ export async function deleteUser(userId: string) {
       const error = await response.json();
       throw new Error(error.error);
     }
-
-    // 연관된 데이터 삭제 (순서 중요)
-    // 1. 알림 삭제
-    await supabase
-      .from("notification")
-      .delete()
-      .or(`from.eq.${userId},to.eq.${userId}`);
-
-    // 2. 친구 요청 삭제
-    await supabase
-      .from("friendRequest")
-      .delete()
-      .or(`from.eq.${userId},to.eq.${userId}`);
-
-    // 3. 댓글 좋아요 삭제
-    await supabase.from("commentLike").delete().eq("userId", userId);
-
-    // 4. 댓글 삭제
-    await supabase.from("comment").delete().eq("userId", userId);
-
-    // 5. 게시글 좋아요 삭제
-    await supabase.from("postLike").delete().eq("userId", userId);
-
-    // 6. 게시글 삭제
-    await supabase.from("post").delete().eq("userId", userId);
-
-    // 7. 운동 기록 삭제
-    await supabase.from("workoutHistory").delete().eq("userId", userId);
-
-    // 8. 유저 데이터 삭제
-    await supabase.from("user").delete().eq("id", userId);
 
     return await response.json();
   } catch (error) {


### PR DESCRIPTION
## 📝 PR 설명
<!-- PR에 대한 설명을 작성해주세요 -->

유저 삭제 로직 rpc로 변경했고 순서는 db정리 - auth 정리로 했습니다.
db 정리가 잘 됐다면 auth는 무조건 존재하므로 삭제가 안 될 케이스가 없어 순서 바꿔도 문제 없다고 판단했습니다!
관련 rpc : delete_user_data

도중 의도치 않은 db 정리 죄송합니다 😭😭😭😭

추가로 기본 아바타도 닉네임 앞글자에서 시안에 존재하는 아바타로 변경했습니다. (기존 의도 + 한글이면 이미지 깨짐 문제)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 삭제 기능 개선: 오류 처리 및 사용자 데이터 삭제를 위한 새로운 RPC 호출 추가.
	- 사용자 등록 시 기본 아바타 URL 사용.

- **버그 수정**
	- 사용자 삭제 중 발생할 수 있는 오류에 대한 알림 메시지 추가. 

- **문서화**
	- 사용자 관련 함수의 구조와 로직 유지, 삭제 방식 간소화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->