### PR TITLE
refactor: 이모티콘이 있는 중앙 모달 리팩토링

### DIFF
--- a/app/(auth)/sign-up/step1.tsx
+++ b/app/(auth)/sign-up/step1.tsx
@@ -1,5 +1,4 @@
-import CustomModal from "@/components/Modal";
-import Icons from "@/constants/icons";
+import { OneButtonModal } from "@/components/Modal";
 import { sendUpOTP, supabase } from "@/utils/supabase";
 import images from "@constants/images";
 import { signUpFormAtom } from "@contexts/auth";
@@ -173,33 +172,20 @@ const Step1 = () => {
           </View>
         </ScrollView>
       </KeyboardAvoidingView>
-      <CustomModal
-        visible={isModalVisible}
+      <OneButtonModal
+        isVisible={isModalVisible}
         onClose={() => {
           setIsModalVisible(false);
           router.push("/sign-up/step2");
         }}
-        position="middle"
-      >
-        <View className="w-full items-center">
-          <View className="w-full items-center px-[55px] py-6">
-            <Icons.FaceDoneIcon width={40} height={40} />
-            <Text className="title-3 mt-4 text-center">
-              이메일로 전송된{"\n"}
-              인증 코드를 확인해주세요!
-            </Text>
-            <TouchableOpacity
-              className="mt-5 h-[62px] w-full items-center justify-center rounded-[10px] bg-primary"
-              onPress={() => {
-                setIsModalVisible(false);
-                router.push("/sign-up/step2");
-              }}
-            >
-              <Text className="title-2 text-white">확인</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      </CustomModal>
+        emoji="happy"
+        contents={"이메일로 전송된\n인증 코드를 확인해주세요!"}
+        buttonText="확인"
+        onPress={() => {
+          setIsModalVisible(false);
+          router.push("/sign-up/step2");
+        }}
+      />
     </>
   );
 };

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -1,5 +1,5 @@
 import CustomSwitch from "@/components/CustomSwitch";
-import CustomModal from "@/components/Modal";
+import { TwoButtonModal } from "@/components/Modal";
 import { showToast } from "@/components/ToastConfig";
 import colors from "@/constants/colors";
 import Icons from "@/constants/icons";
@@ -120,11 +120,47 @@ export default function Setting() {
     };
   });
 
+  // 계정 탈퇴 핸들러
+  const handleDeleteAccount = async () => {
+    setIsLoading(true);
+
+    try {
+      await deleteUser(session?.user.id ?? "");
+
+      router.replace("/sign-in");
+      showToast("success", "탈퇴가 완료되었습니다!");
+    } catch (error) {
+      showToast("error", "탈퇴에 실패했습니다.");
+    }
+
+    setIsDeleteModalVisible(false);
+    setIsLoading(false);
+  };
+
+  // 로그아웃 핸들러
+  const handleSignOut = async () => {
+    if (session) {
+      setIsLoading(true);
+
+      await updatePushToken({
+        userId: session.user.id,
+        pushToken: null,
+      });
+      await supabase.auth.signOut();
+
+      setIsLoading(false);
+    }
+    setIsSignOutModalVisible(false);
+    router.replace("/sign-in");
+
+    showToast("success", "로그아웃이 완료되었습니다!");
+  };
+
   return (
     <SafeAreaView edges={[]} className="flex-1 bg-white">
       <View className="gap-2 bg-gray-5 pb-2">
         {/* 알림 설정 */}
-        <View className="bg-white px-6 py-[22px] gap-5">
+        <View className="gap-5 bg-white px-6 py-[22px]">
           <View className="flex-row items-center justify-between ">
             <Text className="heading-2 text-gray-80">알림 설정</Text>
             <CustomSwitch value={allSwitch} onPress={handleAllSwitchPress} />
@@ -202,100 +238,32 @@ export default function Setting() {
       </View>
 
       <View className="flex-1">
-        <CustomModal
-          visible={isDeleteModalVisible}
+        <TwoButtonModal
+          isVisible={isDeleteModalVisible}
           onClose={() => setIsDeleteModalVisible(false)}
-          position="middle"
-        >
-          <View className="w-full items-center p-[24px]">
-            <Icons.FaceNotDoneIcon width={40} height={40} />
-            <Text className="title-3 mt-4 text-center">
-              탈퇴하면 되돌릴 수 없어요{"\n"}
-              그래도 탈퇴하시겠어요?
-            </Text>
-            <View className="mt-5 flex-row justify-between gap-5">
-              <TouchableOpacity
-                className="h-[52px] w-[127px] items-center justify-center rounded-[10px] bg-gray-40"
-                onPress={() => {
-                  setIsDeleteModalVisible(false);
-                }}
-                disabled={isLoading}
-              >
-                <Text className="title-2 text-white">취소</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                className="h-[52px] w-[127px] items-center justify-center rounded-[10px] bg-primary"
-                onPress={async () => {
-                  setIsLoading(true);
-
-                  try {
-                    await deleteUser(session?.user.id ?? "");
-
-                    router.replace("/sign-in");
-                    showToast("success", "탈퇴가 완료되었습니다!");
-                  } catch (error) {
-                    showToast("error", "탈퇴에 실패했습니다.");
-                  }
-
-                  setIsDeleteModalVisible(false);
-                  setIsLoading(false);
-                }}
-                disabled={isLoading}
-              >
-                <Text className="title-2 text-white">탈퇴</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        </CustomModal>
+          emoji="sad"
+          contents={"탈퇴하면 되돌릴 수 없어요\n그래도 탈퇴하시겠어요?"}
+          leftButtonText="취소"
+          rightButtonText="탈퇴"
+          onLeftButtonPress={() => setIsDeleteModalVisible(false)}
+          onRightButtonPress={handleDeleteAccount}
+          isLoading={isLoading}
+          variant="danger"
+        />
       </View>
 
-      <View className="flex-1 ">
-        <CustomModal
-          visible={isSignOutModalVisible}
+      <View className="flex-1">
+        <TwoButtonModal
+          isVisible={isSignOutModalVisible}
           onClose={() => setIsSignOutModalVisible(false)}
-          position="middle"
-        >
-          <View className="h-[180px] w-full items-center p-[24px]">
-            <Text className="title-3 text-center">
-              이 계정에서{"\n"}
-              로그아웃 하시겠어요?
-            </Text>
-            <View className="mt-[28px] flex-row justify-between gap-5">
-              <TouchableOpacity
-                className="h-[52px] w-[127px] items-center justify-center rounded-[10px] bg-gray-40"
-                onPress={() => {
-                  setIsSignOutModalVisible(false);
-                }}
-                disabled={isLoading}
-              >
-                <Text className="title-2 text-white">취소</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                className="h-[52px] w-[127px] items-center justify-center rounded-[10px] bg-primary"
-                onPress={async () => {
-                  if (session) {
-                    setIsLoading(true);
-
-                    await updatePushToken({
-                      userId: session.user.id,
-                      pushToken: null,
-                    });
-                    await supabase.auth.signOut();
-
-                    setIsLoading(false);
-                  }
-                  setIsSignOutModalVisible(false);
-                  router.replace("/sign-in");
-
-                  showToast("success", "로그아웃이 완료되었습니다!");
-                }}
-                disabled={isLoading}
-              >
-                <Text className="title-2 text-white">로그아웃</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        </CustomModal>
+          contents={"이 계정에서\n로그아웃 하시겠어요?"}
+          leftButtonText="취소"
+          rightButtonText="로그아웃"
+          onLeftButtonPress={() => setIsSignOutModalVisible(false)}
+          onRightButtonPress={handleSignOut}
+          isLoading={isLoading}
+          variant="danger"
+        />
       </View>
     </SafeAreaView>
   );

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -156,6 +156,8 @@ export function TwoButtonModal({
   rightButtonText,
   onLeftButtonPress,
   onRightButtonPress,
+  isLoading,
+  variant = "default",
 }: {
   isVisible: boolean;
   onClose: () => void;
@@ -165,7 +167,19 @@ export function TwoButtonModal({
   rightButtonText: string;
   onLeftButtonPress: () => void;
   onRightButtonPress: () => void;
+  isLoading?: boolean;
+  variant?: "default" | "danger";
 }) {
+  const leftButtonStyle =
+    variant === "danger"
+      ? "h-full flex-1 items-center justify-center rounded-[8px] bg-gray-40"
+      : "h-full flex-1 items-center justify-center rounded-[8px] border-2 border-primary bg-white";
+
+  const leftButtonTextStyle =
+    variant === "danger"
+      ? "font-pbold text-[17px] text-white leading-[150%]"
+      : "font-pbold text-[17px] text-primary leading-[150%]";
+
   return (
     <CustomModal visible={isVisible} onClose={onClose} position="middle">
       <View className="items-center px-7 py-6">
@@ -180,11 +194,10 @@ export function TwoButtonModal({
             onPress={() => {
               onLeftButtonPress();
             }}
-            className="h-full flex-1 items-center justify-center rounded-[8px] border-2 border-primary bg-white"
+            className={leftButtonStyle}
+            disabled={isLoading}
           >
-            <Text className="font-pbold text-[17px] text-primary leading-[150%]">
-              {leftButtonText}
-            </Text>
+            <Text className={leftButtonTextStyle}>{leftButtonText}</Text>
           </TouchableOpacity>
 
           <TouchableOpacity
@@ -192,6 +205,7 @@ export function TwoButtonModal({
               onRightButtonPress();
             }}
             className="h-full flex-1 items-center justify-center rounded-[8px] bg-primary"
+            disabled={isLoading}
           >
             <Text className="font-pbold text-[17px] text-white leading-[150%]">
               {rightButtonText}


### PR DESCRIPTION
## 📝 PR 설명
<!-- PR에 대한 설명을 작성해주세요 -->

이모티콘이 있는 중앙 모달 리팩토링 하였습니다.
기존에 있던 TwoButtonModal 수정했으며 DeleteModal도 사용할 수 있도록 구현하였습니다.

- ~~DeleteModal은 실제로 사용되지 않는 것 같은데 한 번 확인해주시면 좋겠습니다!~~ => 죄송합니다 제가 다른걸 봤나 봅니다 😭😭😭 DeleteModal도 바로 리팩토링 하겠습니다.

- TwoButtonModal류가 회원과 연관된 모달들이라 pushToken 에러로 실제 동작을 확인하지 못했습니다.

추가 리팩토링
- 카메라 선택, 앨범 선택같은 중앙 모달이 두 곳 사용되어 리팩토링 할 예정입니다.
- validation 따로 분리할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 회원가입 단계 1에서 모달을 `OneButtonModal`로 변경하여 사용자 경험을 개선했습니다.
	- 설정 페이지에서 계정 삭제 및 로그아웃 확인을 위한 `TwoButtonModal`을 도입했습니다.
	- 비동기 핸들러 함수 `handleDeleteAccount` 및 `handleSignOut` 추가로 사용자 피드백을 강화했습니다.
	- `TwoButtonModal`에 로딩 상태 및 스타일 변형을 위한 새로운 속성을 추가했습니다.

- **버그 수정**
	- 모달의 상태 관리 및 사용자 입력 검증 로직을 유지하여 일관된 사용자 경험을 보장했습니다. 

- **문서화**
	- 모달 컴포넌트의 새로운 속성 및 기능에 대한 설명을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->