### PR TITLE
feat: 푸시알림 권한설정 및 알림 설정 로직 완성 및 리팩토링

### DIFF
--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -199,13 +199,11 @@ export default function Setting() {
 
                     setIsLoading(false);
                   }
-                  setIsSignOutModalVisible(false);
+                  queryClient.clear();
 
-                  queryClient.refetchQueries({ queryKey: ["session"] });
-                  queryClient.refetchQueries({ queryKey: ["currentUser"] });
+                  setIsSignOutModalVisible(false);
                   // 아마 세션 여부에 따른 리다이렉트 되면 자동 이동 될지도
                   router.replace("/sign-in");
-
                   showToast("success", "로그아웃이 완료되었습니다!");
                 }}
                 disabled={isLoading}

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -9,6 +9,7 @@ import type {
   NotificationType,
   PushToken,
 } from "@/types/Notification.interface";
+import { isTokenValid } from "@/utils/pushTokenManager";
 import {
   deleteUser,
   getCurrentSession,
@@ -42,7 +43,7 @@ export default function Setting() {
   // 푸시알림 설정 정보 조회
   const { data: token, isPending: isTokenPending } =
     useFetchData<PushToken | null>(
-      ["pushToken", session?.user.id],
+      ["pushTokenData"],
       () => getPushToken(session?.user.id || ""),
       "푸시 알림 설정 정보 로드에 실패했습니다.",
       !!session,
@@ -269,10 +270,7 @@ function NotificationSetting({
         allSwitch.value = true;
         isAllSwitchInit.value = false;
         // 기존에 푸시 알람 권한 허용이 제대로 되지 않았던 경우
-        if (
-          !token?.pushToken ||
-          !token.pushToken.startsWith("ExponentPushToken")
-        ) {
+        if (isTokenValid(token?.pushToken)) {
         }
       }
     } else if (
@@ -298,7 +296,7 @@ function NotificationSetting({
 
     if (JSON.stringify(granted.sort()) !== JSON.stringify(newGranted.sort())) {
       await updatePushToken({ userId, grantedNotifications: newGranted });
-      queryClient.invalidateQueries({ queryKey: ["pushToken", userId] });
+      queryClient.refetchQueries({ queryKey: ["pushTokenData"] });
     }
   }, [queryClient, SWITCH_CONFIG, userId, granted]);
 

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -1,4 +1,5 @@
 import CustomSwitch from "@/components/CustomSwitch";
+import LoadingScreen from "@/components/LoadingScreen";
 import CustomModal from "@/components/Modal";
 import { showToast } from "@/components/ToastConfig";
 import colors from "@/constants/colors";
@@ -25,7 +26,6 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Setting() {
   const router = useRouter();
-  const queryClient = useQueryClient();
 
   const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
   const [isSignOutModalVisible, setIsSignOutModalVisible] = useState(false);
@@ -40,113 +40,25 @@ export default function Setting() {
   );
 
   // 푸시알림 설정 정보 조회
-  const { data: token } = useFetchData<PushToken | null>(
-    ["pushToken", session?.user.id],
-    () => getPushToken(session?.user.id || ""),
-    "푸시 알림 설정 정보 로드에 실패했습니다.",
-    !!session,
-  );
-
-  const granted = token?.grantedNotifications || [];
-  const allSwitch = useSharedValue(!!granted.length);
-  const SWITCH_CONFIG = {
-    like: {
-      title: "좋아요 알림",
-      value: useSharedValue(granted.includes("like")),
-    },
-    comment: {
-      title: "댓글 알림",
-      value: useSharedValue(granted.includes("comment")),
-    },
-    mention: {
-      title: "언급 알림",
-      value: useSharedValue(granted.includes("mention")),
-    },
-    poke: {
-      title: "콕찌르기 알림",
-      value: useSharedValue(granted.includes("poke")),
-    },
-    friend: {
-      title: "친구요청 알림",
-      value: useSharedValue(granted.includes("friend")),
-    },
-  };
-  type SwitchType = keyof typeof SWITCH_CONFIG;
-
-  // 최상단 스위치 클릭 핸들러
-  const handleAllSwitchPress = () => {
-    for (const { value } of Object.values(SWITCH_CONFIG)) {
-      value.value = !allSwitch.value;
-    }
-    allSwitch.value = !allSwitch.value;
-  };
-
-  // 개별 스위치 클릭 핸들러
-  const handleSwitchPress = (type: SwitchType) => {
-    if (!SWITCH_CONFIG[type].value.value) {
-      // 이전값이 false -> 이제 true: 하나라도 true면 allSwitch는 true
-      if (!allSwitch.value) allSwitch.value = true;
-    } else if (
-      // 이전값이 true -> 이제 false: 나 제외 나머지 것들도 다 false 이면 allSwitch도 false
-      Object.entries(SWITCH_CONFIG).every(
-        ([key, { value }]) => key === type || !value.value,
-      )
-    ) {
-      if (allSwitch.value) allSwitch.value = false;
-    }
-
-    SWITCH_CONFIG[type].value.value = !SWITCH_CONFIG[type].value.value;
-  };
-
-  // 알림 설정 변경 사항 업데이트
-  const updateGrantedNotifications = useCallback(
-    async (userId: string, grantedNotifications: NotificationType[]) => {
-      await updatePushToken({ userId, grantedNotifications });
-      queryClient.invalidateQueries({ queryKey: ["pushToken", userId] });
-    },
-    [queryClient.invalidateQueries],
-  );
-
-  useFocusEffect(() => {
-    return () => {
-      if (!session) return;
-
-      const newGranted = Object.entries(SWITCH_CONFIG)
-        .filter(([, { value }]) => value.value)
-        .map(([key]) => key as NotificationType);
-
-      if (JSON.stringify(granted.sort()) !== JSON.stringify(newGranted.sort()))
-        updateGrantedNotifications(session.user.id, newGranted);
-    };
-  });
+  const { data: token, isPending: isTokenPending } =
+    useFetchData<PushToken | null>(
+      ["pushToken", session?.user.id],
+      () => getPushToken(session?.user.id || ""),
+      "푸시 알림 설정 정보 로드에 실패했습니다.",
+      !!session,
+    );
 
   return (
     <SafeAreaView edges={[]} className="flex-1 bg-white">
       <View className="gap-2 bg-gray-5 pb-2">
         {/* 알림 설정 */}
-        <View className="bg-white px-6 py-[22px] gap-5">
-          <View className="flex-row items-center justify-between ">
-            <Text className="heading-2 text-gray-80">알림 설정</Text>
-            <CustomSwitch value={allSwitch} onPress={handleAllSwitchPress} />
+        {!session || isTokenPending ? (
+          <View className="h-[324px] items-center justify-center">
+            <LoadingScreen />
           </View>
-          {/* 개별 스위치 리스트 */}
-          <View className="gap-5 px-2">
-            {Object.keys(SWITCH_CONFIG).map((type) => (
-              <View
-                key={type}
-                className="flex-row items-center justify-between"
-              >
-                <Text className="font-pmedium text-gray-80 text-xl">
-                  {SWITCH_CONFIG[type as SwitchType].title}
-                </Text>
-                <CustomSwitch
-                  value={SWITCH_CONFIG[type as SwitchType].value}
-                  onPress={() => handleSwitchPress(type as SwitchType)}
-                />
-              </View>
-            ))}
-          </View>
-        </View>
+        ) : (
+          <NotificationSetting userId={session.user.id} token={token} />
+        )}
 
         {/* 계정 설정 */}
         <View className="bg-white px-6 py-[22px]">
@@ -298,5 +210,135 @@ export default function Setting() {
         </CustomModal>
       </View>
     </SafeAreaView>
+  );
+}
+
+function NotificationSetting({
+  userId,
+  token,
+}: { userId: string; token?: PushToken | null }) {
+  const queryClient = useQueryClient();
+
+  const granted = token?.grantedNotifications || [];
+  const allSwitch = useSharedValue(!!granted.length);
+  const isAllSwitchInit = useSharedValue(true);
+  const SWITCH_CONFIG = {
+    like: {
+      title: "좋아요 알림",
+      value: useSharedValue(granted.includes("like")),
+      isInit: useSharedValue(true),
+    },
+    comment: {
+      title: "댓글 알림",
+      value: useSharedValue(granted.includes("comment")),
+      isInit: useSharedValue(true),
+    },
+    mention: {
+      title: "언급 알림",
+      value: useSharedValue(granted.includes("mention")),
+      isInit: useSharedValue(true),
+    },
+    poke: {
+      title: "콕찌르기 알림",
+      value: useSharedValue(granted.includes("poke")),
+      isInit: useSharedValue(true),
+    },
+    friend: {
+      title: "친구요청 알림",
+      value: useSharedValue(granted.includes("friend")),
+      isInit: useSharedValue(true),
+    },
+  };
+  type SwitchType = keyof typeof SWITCH_CONFIG;
+
+  // 최상단 스위치 클릭 핸들러
+  const handleAllSwitchPress = () => {
+    for (const { value, isInit } of Object.values(SWITCH_CONFIG)) {
+      value.value = !allSwitch.value;
+      isInit.value = false;
+    }
+    allSwitch.value = !allSwitch.value;
+    isAllSwitchInit.value = false;
+  };
+
+  // 개별 스위치 클릭 핸들러
+  const handleSwitchPress = (type: SwitchType) => {
+    if (!SWITCH_CONFIG[type].value.value) {
+      // 이전값이 false -> 이제 true: 하나라도 true면 allSwitch는 true
+      if (!allSwitch.value) {
+        allSwitch.value = true;
+        isAllSwitchInit.value = false;
+        // 기존에 푸시 알람 권한 허용이 제대로 되지 않았던 경우
+        if (
+          !token?.pushToken ||
+          !token.pushToken.startsWith("ExponentPushToken")
+        ) {
+        }
+      }
+    } else if (
+      // 이전값이 true -> 이제 false: 나 제외 나머지 것들도 다 false 이면 allSwitch도 false
+      Object.entries(SWITCH_CONFIG).every(
+        ([key, { value }]) => key === type || !value.value,
+      ) &&
+      allSwitch.value
+    ) {
+      allSwitch.value = false;
+      isAllSwitchInit.value = false;
+    }
+
+    SWITCH_CONFIG[type].value.value = !SWITCH_CONFIG[type].value.value;
+    SWITCH_CONFIG[type].isInit.value = false;
+  };
+
+  // 알림 설정 변경 사항 업데이트
+  const updateGrantedNotifications = useCallback(
+    async (userId: string, grantedNotifications: NotificationType[]) => {
+      await updatePushToken({ userId, grantedNotifications });
+      queryClient.invalidateQueries({ queryKey: ["pushToken", userId] });
+    },
+    [queryClient.invalidateQueries],
+  );
+
+  // 설정화면에서 떠날 때 알림 설정 변경사항 저장
+  useFocusEffect(() => {
+    return () => {
+      if (!userId) return;
+      const granted = token?.grantedNotifications || [];
+
+      const newGranted = Object.entries(SWITCH_CONFIG)
+        .filter(([, { value }]) => value.value)
+        .map(([key]) => key as NotificationType);
+
+      if (JSON.stringify(granted.sort()) !== JSON.stringify(newGranted.sort()))
+        updateGrantedNotifications(userId, newGranted);
+    };
+  });
+
+  return (
+    <View className="bg-white px-6 py-[22px] gap-5">
+      <View className="flex-row items-center justify-between ">
+        <Text className="heading-2 text-gray-80">알림 설정</Text>
+        <CustomSwitch
+          value={allSwitch}
+          isInit={isAllSwitchInit}
+          onPress={handleAllSwitchPress}
+        />
+      </View>
+      {/* 개별 스위치 리스트 */}
+      <View className="gap-5 px-2">
+        {Object.keys(SWITCH_CONFIG).map((type) => (
+          <View key={type} className="flex-row items-center justify-between">
+            <Text className="font-pmedium text-gray-80 text-xl">
+              {SWITCH_CONFIG[type as SwitchType].title}
+            </Text>
+            <CustomSwitch
+              value={SWITCH_CONFIG[type as SwitchType].value}
+              isInit={SWITCH_CONFIG[type as SwitchType].isInit}
+              onPress={() => handleSwitchPress(type as SwitchType)}
+            />
+          </View>
+        ))}
+      </View>
+    </View>
   );
 }

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -20,7 +20,7 @@ import {
 import type { Session } from "@supabase/supabase-js";
 import { useQueryClient } from "@tanstack/react-query";
 import { useFocusEffect, useRouter } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Linking, Text, TouchableOpacity, View } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -225,7 +225,6 @@ function NotificationSetting({
 }: { userId: string; setting?: PushSetting | null }) {
   const queryClient = useQueryClient();
 
-  const [isInit, setIsInit] = useState(true);
   const granted = setting?.grantedNotifications || [];
   const allSwitch = useSharedValue(!!granted.length);
   const isAllSwitchInit = useSharedValue(true);
@@ -261,14 +260,6 @@ function NotificationSetting({
   const handleUpdate = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["pushToken"] });
   }, [queryClient]);
-
-  // 모두 값을 false로 변경
-  const setAllFalse = useCallback(() => {
-    for (const { value } of Object.values(SWITCH_CONFIG)) {
-      value.value = false;
-    }
-    allSwitch.value = false;
-  }, [allSwitch, SWITCH_CONFIG]);
 
   // 최상단 스위치 클릭 핸들러
   const handleAllSwitchPress = async () => {
@@ -333,13 +324,6 @@ function NotificationSetting({
       queryClient.invalidateQueries({ queryKey: ["pushToken"] });
     }
   }, [queryClient, SWITCH_CONFIG, userId, granted]);
-
-  // 초기에 토큰정보가 올바르지 않으면 모두 false로 설정
-  useEffect(() => {
-    if (!isInit) return;
-    if (!isTokenValid(setting?.token)) setAllFalse();
-    if (setting !== undefined) setIsInit(false);
-  }, [setAllFalse, setting, isInit]);
 
   // 설정화면에서 떠날 때 알림 설정 변경사항 저장
   useFocusEffect(() => {

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -26,6 +26,14 @@ import { Linking, Platform, Text, TouchableOpacity, View } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+const NOTIFICATION_TYPE_GROUPS: { [key: string]: NotificationType[] } = {
+  like: ["like", "commentLike"],
+  comment: ["comment"],
+  mention: ["mention"],
+  poke: ["poke"],
+  friend: ["friend"],
+} as const;
+
 export default function Setting() {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -331,16 +339,10 @@ function NotificationSetting({
     SWITCH_CONFIG[type].isInit.value = false;
 
     // DB에 변경사항 반영
-    let newGranted = granted;
-    if (!prevValue) {
-      newGranted = granted.concat(
-        type === "like" ? ["like", "commentLike"] : type,
-      );
-    } else {
-      newGranted = granted.filter((t) =>
-        type === "like" ? !["like", "commentLike"].includes(t) : type !== t,
-      );
-    }
+    const typesToUpdate = NOTIFICATION_TYPE_GROUPS[type];
+    const newGranted = prevValue
+      ? granted.filter((t) => !typesToUpdate.includes(t))
+      : [...granted, ...typesToUpdate];
     updateGrantedNotifications(newGranted);
   };
 

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -236,7 +236,7 @@ function NotificationSetting({
       isInit: useSharedValue(true),
     },
     mention: {
-      title: "언급 알림",
+      title: "멘션 알림",
       value: useSharedValue(granted.includes("mention")),
       isInit: useSharedValue(true),
     },

--- a/app/setting.tsx
+++ b/app/setting.tsx
@@ -253,9 +253,14 @@ function NotificationSetting({
   } as const;
   type SwitchType = keyof typeof SWITCH_CONFIG;
 
+  const handleUpdate = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["pushToken"] });
+    queryClient.refetchQueries({ queryKey: ["pushTokenSetting"] });
+  }, [queryClient]);
+
   // 모두 값을 false로 변경
   const setAllFalse = useCallback(() => {
-    for (const { value, isInit } of Object.values(SWITCH_CONFIG)) {
+    for (const { value } of Object.values(SWITCH_CONFIG)) {
       value.value = false;
     }
     allSwitch.value = false;
@@ -263,14 +268,12 @@ function NotificationSetting({
 
   // 최상단 스위치 클릭 핸들러
   const handleAllSwitchPress = async () => {
+    // 기존에 푸시 알람 권한 허용이 제대로 되지 않았던 경우
     if (!isTokenValid(setting?.token)) {
       const isSuccess = await reRequestToken({
         userId,
         token: setting?.token,
-        handleUpdate: () =>
-          queryClient.invalidateQueries({
-            queryKey: ["pushTokenSetting"],
-          }),
+        handleUpdate,
       });
       if (!isSuccess) return;
     }
@@ -292,10 +295,7 @@ function NotificationSetting({
         const isSuccess = await reRequestToken({
           userId,
           token: setting?.token,
-          handleUpdate: () =>
-            queryClient.invalidateQueries({
-              queryKey: ["pushTokenSetting"],
-            }),
+          handleUpdate,
         });
         if (!isSuccess) return;
       }

--- a/app/user/[userId].tsx
+++ b/app/user/[userId].tsx
@@ -5,6 +5,7 @@ import ProfileSection from "@/components/ProfileSection";
 import useFetchData from "@/hooks/useFetchData";
 import useManageFriend from "@/hooks/useManageFriend";
 import { RELATION_TYPE, type RelationType } from "@/types/Friend.interface";
+import type { UserProfile } from "@/types/User.interface";
 import {
   getCurrentUser,
   getFriendStatus,
@@ -19,14 +20,14 @@ import { Text, TouchableOpacity, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 interface RequestButtonProps {
-  currentUserId: string;
+  currentUser: UserProfile;
   userId: string;
   relation: RelationType;
   onPress: () => void;
 }
 
 function RequestButton({
-  currentUserId,
+  currentUser,
   userId,
   relation,
   onPress,
@@ -40,22 +41,20 @@ function RequestButton({
     [RELATION_TYPE.FRIEND]: {
       message: "친구 끊기",
       onPress: () =>
-        handleUnfriend({ fromUserId: currentUserId, toUserId: userId }),
+        handleUnfriend({ fromUserId: currentUser.id, toUserId: userId }),
     },
     [RELATION_TYPE.ASKING]: {
       message: "친구 요청 취소",
       onPress: () =>
-        handleUnfriend({ fromUserId: currentUserId, toUserId: userId }),
+        handleUnfriend({ fromUserId: currentUser.id, toUserId: userId }),
     },
     [RELATION_TYPE.ASKED]: {
       message: "친구 요청 수락",
-      onPress: () =>
-        handleAccept({ fromUserId: userId, toUserId: currentUserId }),
+      onPress: () => handleAccept({ fromUserId: userId, toUser: currentUser }),
     },
     [RELATION_TYPE.NONE]: {
       message: "친구 요청",
-      onPress: () =>
-        handleCreate({ fromUserId: currentUserId, toUserId: userId }),
+      onPress: () => handleCreate({ fromUser: currentUser, toUserId: userId }),
     },
   };
 
@@ -162,7 +161,7 @@ const User = () => {
         <View className="items-center">
           {relation && currentUser && !isRelationPending && (
             <RequestButton
-              currentUserId={currentUser.id}
+              currentUser={currentUser}
               userId={userId as string}
               relation={relation}
               onPress={() => setIsModalVisible(false)}

--- a/components/CustomSwitch.tsx
+++ b/components/CustomSwitch.tsx
@@ -14,8 +14,8 @@ interface SwitchProps {
   onPress: () => void;
   duration?: number;
   size?: {
-    switchWidth: number;
-    switchHeight: number;
+    width: number;
+    height: number;
     padding: number;
   };
   trackColors?: { on: string; off: string };
@@ -26,10 +26,10 @@ export default function CustomSwitch({
   isInit,
   onPress,
   duration = 400,
-  size = { switchWidth: 45, switchHeight: 22, padding: 3 },
+  size = { width: 45, height: 22, padding: 3 },
   trackColors = { on: colors.primary, off: colors.gray[25] },
 }: SwitchProps) {
-  const thumbSize = size.switchHeight - 2 * size.padding;
+  const thumbSize = size.height - 2 * size.padding;
 
   const trackAnimatedStyle = useAnimatedStyle(() => {
     const color = interpolateColor(
@@ -43,7 +43,7 @@ export default function CustomSwitch({
 
     return {
       backgroundColor: colorValue,
-      borderRadius: size.switchHeight / 2,
+      borderRadius: size.height / 2,
     };
   });
 
@@ -51,7 +51,7 @@ export default function CustomSwitch({
     const moveValue = interpolate(
       Number(value.value),
       [0, 1],
-      [0, size.switchWidth - size.switchHeight],
+      [0, size.width - size.height],
     );
     const translateValue = withTiming(moveValue, {
       duration: isInit.value ? 0 : duration,
@@ -59,19 +59,16 @@ export default function CustomSwitch({
 
     return {
       transform: [{ translateX: translateValue }],
-      borderRadius: size.switchHeight / 2,
+      borderRadius: size.height / 2,
     };
   });
 
   return (
     <TouchableWithoutFeedback onPress={onPress}>
-      <Animated.View
-        className={`w-[${size.switchWidth}px] h-[${size.switchHeight}px] p-[${size.padding}px]`}
-        style={[trackAnimatedStyle]}
-      >
+      <Animated.View style={[trackAnimatedStyle, size]}>
         <Animated.View
           className={`size-[${thumbSize}px] bg-white`}
-          style={[thumbAnimatedStyle]}
+          style={[thumbAnimatedStyle, { width: thumbSize, height: thumbSize }]}
         />
       </Animated.View>
     </TouchableWithoutFeedback>

--- a/components/CustomSwitch.tsx
+++ b/components/CustomSwitch.tsx
@@ -5,7 +5,6 @@ import Animated, {
   interpolateColor,
   type SharedValue,
   useAnimatedStyle,
-  useSharedValue,
   withTiming,
 } from "react-native-reanimated";
 
@@ -14,6 +13,11 @@ interface SwitchProps {
   isInit: SharedValue<boolean>;
   onPress: () => void;
   duration?: number;
+  size?: {
+    switchWidth: number;
+    switchHeight: number;
+    padding: number;
+  };
   trackColors?: { on: string; off: string };
 }
 
@@ -22,10 +26,10 @@ export default function CustomSwitch({
   isInit,
   onPress,
   duration = 400,
+  size = { switchWidth: 45, switchHeight: 22, padding: 3 },
   trackColors = { on: colors.primary, off: colors.gray[25] },
 }: SwitchProps) {
-  const height = useSharedValue(0);
-  const width = useSharedValue(0);
+  const thumbSize = size.switchHeight - 2 * size.padding;
 
   const trackAnimatedStyle = useAnimatedStyle(() => {
     const color = interpolateColor(
@@ -39,7 +43,7 @@ export default function CustomSwitch({
 
     return {
       backgroundColor: colorValue,
-      borderRadius: height.value / 2,
+      borderRadius: size.switchHeight / 2,
     };
   });
 
@@ -47,7 +51,7 @@ export default function CustomSwitch({
     const moveValue = interpolate(
       Number(value.value),
       [0, 1],
-      [0, width.value - height.value],
+      [0, size.switchWidth - size.switchHeight],
     );
     const translateValue = withTiming(moveValue, {
       duration: isInit.value ? 0 : duration,
@@ -55,22 +59,18 @@ export default function CustomSwitch({
 
     return {
       transform: [{ translateX: translateValue }],
-      borderRadius: height.value / 2,
+      borderRadius: size.switchHeight / 2,
     };
   });
 
   return (
     <TouchableWithoutFeedback onPress={onPress}>
       <Animated.View
-        onLayout={(e) => {
-          height.value = e.nativeEvent.layout.height;
-          width.value = e.nativeEvent.layout.width;
-        }}
-        className="w-[45px] h-[22px] p-[3px]"
+        className={`w-[${size.switchWidth}px] h-[${size.switchHeight}px] p-[${size.padding}px]`}
         style={[trackAnimatedStyle]}
       >
         <Animated.View
-          className="size-[16px] bg-white"
+          className={`size-[${thumbSize}px] bg-white`}
           style={[thumbAnimatedStyle]}
         />
       </Animated.View>

--- a/components/CustomSwitch.tsx
+++ b/components/CustomSwitch.tsx
@@ -67,7 +67,7 @@ export default function CustomSwitch({
     <TouchableWithoutFeedback onPress={onPress}>
       <Animated.View style={[trackAnimatedStyle, size]}>
         <Animated.View
-          className={`size-[${thumbSize}px] bg-white`}
+          className="bg-white"
           style={[thumbAnimatedStyle, { width: thumbSize, height: thumbSize }]}
         />
       </Animated.View>

--- a/components/CustomSwitch.tsx
+++ b/components/CustomSwitch.tsx
@@ -9,19 +9,21 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 
-interface ToggleProps {
+interface SwitchProps {
   value: SharedValue<boolean>;
-  onPress?: () => void;
+  isInit: SharedValue<boolean>;
+  onPress: () => void;
   duration?: number;
   trackColors?: { on: string; off: string };
 }
 
 export default function CustomSwitch({
   value,
+  isInit,
   onPress,
   duration = 400,
   trackColors = { on: colors.primary, off: colors.gray[25] },
-}: ToggleProps) {
+}: SwitchProps) {
   const height = useSharedValue(0);
   const width = useSharedValue(0);
 
@@ -31,7 +33,9 @@ export default function CustomSwitch({
       [0, 1],
       [trackColors.off, trackColors.on],
     );
-    const colorValue = withTiming(color, { duration });
+    const colorValue = withTiming(color, {
+      duration: isInit.value ? 0 : duration,
+    });
 
     return {
       backgroundColor: colorValue,
@@ -45,7 +49,9 @@ export default function CustomSwitch({
       [0, 1],
       [0, width.value - height.value],
     );
-    const translateValue = withTiming(moveValue, { duration });
+    const translateValue = withTiming(moveValue, {
+      duration: isInit.value ? 0 : duration,
+    });
 
     return {
       transform: [{ translateX: translateValue }],

--- a/components/FriendItem.tsx
+++ b/components/FriendItem.tsx
@@ -20,7 +20,7 @@ interface FriendItemProps {
 
 interface FriendRequestProps {
   requestId: number;
-  toUserId: string;
+  toUser: UserProfile;
   fromUser: UserProfile;
   isLoading: boolean;
 }
@@ -112,7 +112,7 @@ export function FriendItem({ friend }: FriendItemProps) {
 
 export function FriendRequest({
   requestId,
-  toUserId,
+  toUser,
   fromUser,
   isLoading,
 }: FriendRequestProps) {
@@ -130,7 +130,7 @@ export function FriendRequest({
         <TouchableOpacity
           className="bg-primary px-[12px] py-[11px] rounded-[10px]"
           onPress={() =>
-            handleAccept({ requestId, fromUserId: fromUser.id, toUserId })
+            handleAccept({ requestId, fromUserId: fromUser.id, toUser })
           }
           disabled={isAcceptPending || isRefusePending || isLoading}
           accessibilityLabel="친구 요청 수락"
@@ -142,7 +142,11 @@ export function FriendRequest({
         <TouchableOpacity
           className="bg-white  px-[12px] py-[11px] rounded-[10px] border-primary border-[1px]"
           onPress={() =>
-            handleRefuse({ requestId, fromUserId: fromUser.id, toUserId })
+            handleRefuse({
+              requestId,
+              fromUserId: fromUser.id,
+              toUserId: toUser.id,
+            })
           }
           disabled={isAcceptPending || isRefusePending || isLoading}
           accessibilityLabel="친구 요청 거절"

--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -13,7 +13,11 @@ export function NotificationItem({
   createdAt,
 }: NotificationResponse) {
   const diff = diffDate(new Date(createdAt));
-  const message = formMessage(type, from.username, data?.commentInfo?.content);
+  const message = formMessage({
+    type,
+    username: from.username,
+    comment: data?.commentInfo?.content,
+  });
 
   return (
     <TouchableWithoutFeedback

--- a/providers/notificationProvider.tsx
+++ b/providers/notificationProvider.tsx
@@ -1,12 +1,17 @@
 import useFetchData from "@/hooks/useFetchData";
 import type { PushSetting } from "@/types/Notification.interface";
 import { addPushToken, updatePushToken } from "@/utils/pushTokenManager";
-import { getCurrentSession, getPushSetting } from "@/utils/supabase";
+import {
+  getCurrentSession,
+  getPushSetting,
+  updatePushSetting,
+} from "@/utils/supabase";
 import type { Session } from "@supabase/supabase-js";
 import { useQueryClient } from "@tanstack/react-query";
 import * as Notifications from "expo-notifications";
 import { router } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import { AppState } from "react-native";
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -23,6 +28,7 @@ interface Props {
 export default function NotificationProvider({ children }: Props) {
   const queryClient = useQueryClient();
   const [isInit, setIsInit] = useState(true);
+  const [pushPermission, setPushPermission] = useState("");
 
   // 로그인한 유저 정보 조회
   const { data: session } = useFetchData<Session>(
@@ -40,23 +46,23 @@ export default function NotificationProvider({ children }: Props) {
       !!session,
     );
 
-  // 푸시알람 관련 정보 업데이트 시 캐시된 데이터 삭제, 더이상 첫 업데이트 아님을 마킹
-  const handleUpdate = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: ["pushToken"] });
-    queryClient.invalidateQueries({ queryKey: ["pushTokenSetting"] });
-    setIsInit(false);
-  }, [queryClient]);
-
   // 세션 바뀔 때마다 isInit true로 바꿈
   useEffect(() => {
     if (!session) return;
     setIsInit(true);
   }, [session]);
 
-  // session과 token 유효하고, 로그인 한 첫회에만 푸시 토큰 업데이트
+  // 로그인 한 첫회에만 푸시 토큰 업데이트
   useEffect(() => {
     if (!session || isTokenPending) return;
     if (!isInit) return;
+
+    // 푸시알람 관련 정보 업데이트 시 캐시된 데이터 삭제, 더이상 첫 업데이트 아님을 마킹
+    const handleUpdate = () => {
+      queryClient.invalidateQueries({ queryKey: ["pushToken"] });
+      queryClient.invalidateQueries({ queryKey: ["pushTokenSetting"] });
+      setIsInit(false);
+    };
 
     const userId = session.user.id;
     if (pushSetting) {
@@ -68,7 +74,7 @@ export default function NotificationProvider({ children }: Props) {
     } else {
       addPushToken({ userId, handleUpdate });
     }
-  }, [session, pushSetting, isTokenPending, isInit, handleUpdate]);
+  }, [session, pushSetting, isTokenPending, isInit, queryClient]);
 
   // 푸시 알림 관련 포스트 페이지로 바로 이동
   useEffect(() => {
@@ -87,6 +93,41 @@ export default function NotificationProvider({ children }: Props) {
 
     return () => subscription.remove();
   }, []);
+
+  // 권한 설정 변경 감지
+  useEffect(() => {
+    // 앱 푸시알림 설정 변경 시 관련 정보 리패치
+    const handleUpdate = () => {
+      queryClient.refetchQueries({ queryKey: ["pushToken"] });
+      queryClient.refetchQueries({ queryKey: ["pushTokenSetting"] });
+    };
+
+    // 권한 설정 정보 저장
+    const handlePermissionChange = async () => {
+      const { status } = await Notifications.getPermissionsAsync();
+      if (status === pushPermission || !session) return;
+
+      const userId = session.user.id;
+      if (status === "granted") {
+        await updatePushToken({ userId, existingToken: null, handleUpdate });
+      } else {
+        await updatePushSetting({ userId, token: null });
+        handleUpdate();
+      }
+
+      setPushPermission(status);
+    };
+
+    // 앱이 foreground 로 돌아왔을 때 권한변경 감지
+    const subscription = AppState.addEventListener("change", (nextAppState) => {
+      if (nextAppState === "active") {
+        console.log("welcome back");
+        handlePermissionChange();
+      }
+    });
+
+    return () => subscription.remove();
+  }, [pushPermission, session, queryClient]);
 
   return children;
 }

--- a/providers/notificationProvider.tsx
+++ b/providers/notificationProvider.tsx
@@ -4,7 +4,7 @@ import { addPushToken, updatePushToken } from "@/utils/pushTokenManager";
 import {
   getCurrentSession,
   getPushSetting,
-  updatePushSetting,
+  resetPushSetting,
 } from "@/utils/supabase";
 import type { Session } from "@supabase/supabase-js";
 import { useQueryClient } from "@tanstack/react-query";
@@ -115,7 +115,7 @@ export default function NotificationProvider({ children }: Props) {
       if (status === "granted") {
         await updatePushToken({ userId, existingToken: null, handleUpdate });
       } else {
-        await updatePushSetting({ userId, token: null });
+        await resetPushSetting(userId);
         handleUpdate();
       }
 

--- a/providers/notificationProvider.tsx
+++ b/providers/notificationProvider.tsx
@@ -86,12 +86,20 @@ export default function NotificationProvider({ children }: Props) {
     const subscription = Notifications.addNotificationResponseReceivedListener(
       (response) => {
         const { data } = response.notification.request.content;
-        if (!data) {
-          // 찌르기나 친구 요청 수락 알림
-          router.navigate("/friend");
-        } else {
+        if (!Object.keys(data).length) {
+          // 찌르기
+          router.navigate("/home");
+        } else if (data.postId) {
           // 게시글 댓글, 좋아요, 멘션, 댓글 좋아요 알림
           router.navigate(`/post/${data.postId}`);
+        } else {
+          if (data.isAccepted) {
+            // 친구 수락
+            router.navigate("/friend");
+          } else {
+            // 친구 요청
+            router.navigate("/friend/request");
+          }
         }
       },
     );

--- a/providers/notificationProvider.tsx
+++ b/providers/notificationProvider.tsx
@@ -1,22 +1,12 @@
 import useFetchData from "@/hooks/useFetchData";
-import {
-  NOTIFICATION_TYPE,
-  type PushToken,
-} from "@/types/Notification.interface";
-import {
-  createPushToken,
-  getCurrentSession,
-  getPushToken,
-  updatePushToken,
-} from "@/utils/supabase";
+import type { PushToken } from "@/types/Notification.interface";
+import { addPushToken, updatePushToken } from "@/utils/pushTokenManager";
+import { getCurrentSession, getPushToken } from "@/utils/supabase";
 import type { Session } from "@supabase/supabase-js";
 import { useQueryClient } from "@tanstack/react-query";
-import Constants from "expo-constants";
-import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
 import { router } from "expo-router";
-import { useEffect, useState } from "react";
-import { Platform } from "react-native";
+import { useCallback, useEffect } from "react";
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -31,7 +21,6 @@ interface Props {
 }
 
 export default function NotificationProvider({ children }: Props) {
-  const [expoPushToken, setExpoPushToken] = useState("");
   const queryClient = useQueryClient();
 
   // 로그인한 유저 정보 조회
@@ -41,19 +30,21 @@ export default function NotificationProvider({ children }: Props) {
     "로그인 정보 조회에 실패했습니다.",
   );
 
+  // 기존 푸시 알림 정보 조회
   const { data: token, isPending: isTokenPending } =
     useFetchData<PushToken | null>(
-      ["pushToken", session?.user.id],
+      ["pushToken"],
       () => getPushToken(session?.user.id || ""),
       "푸시 알림 설정 정보 로드에 실패했습니다.",
       !!session,
     );
 
-  useEffect(() => {
-    registerForPushNotificationsAsync()
-      .then((token) => setExpoPushToken(token ?? ""))
-      .catch((error) => setExpoPushToken(`${error}`));
+  const handleUpdate = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["pushToken"] });
+    queryClient.invalidateQueries({ queryKey: ["pushTokenData"] });
+  }, [queryClient]);
 
+  useEffect(() => {
     // 푸시 알림 관련 포스트 페이지로 바로 이동
     const subscription = Notifications.addNotificationResponseReceivedListener(
       (response) => {
@@ -72,81 +63,14 @@ export default function NotificationProvider({ children }: Props) {
   }, []);
 
   useEffect(() => {
-    if (!session || !expoPushToken) return;
-    const userId = session.user.id;
+    if (!session || isTokenPending) return;
 
-    if (
-      !isTokenPending &&
-      !token &&
-      expoPushToken.startsWith("ExponentPushToken")
-    ) {
-      // 새로 토큰 등록하는 경우: 저장된 token이 없고, 새 토큰이 유효함
-      createPushToken({
-        userId,
-        pushToken: expoPushToken,
-        grantedNotifications: Object.values(NOTIFICATION_TYPE),
-      });
-      queryClient.invalidateQueries({ queryKey: ["pushToken", userId] });
-      return;
+    if (token) {
+      updatePushToken(session.user.id, token.pushToken, handleUpdate);
+    } else {
+      addPushToken(session.user.id, handleUpdate);
     }
-
-    // 토큰 값이 달라진 경우: 토큰은 있지만, 새로 얻은 것과 다름
-    if (token && token.pushToken !== expoPushToken) {
-      updatePushToken({ userId, pushToken: expoPushToken });
-      queryClient.invalidateQueries({ queryKey: ["pushToken", userId] });
-      return;
-    }
-  }, [session, token, isTokenPending, expoPushToken, queryClient]);
+  }, [session, token, isTokenPending, handleUpdate]);
 
   return children;
-}
-
-function handleRegistrationError(errorMessage: string) {
-  alert(errorMessage);
-  throw new Error(errorMessage);
-}
-
-async function registerForPushNotificationsAsync() {
-  // 안드로이드 알림 설정
-  if (Platform.OS === "android") {
-    Notifications.setNotificationChannelAsync("default", {
-      name: "default",
-      importance: Notifications.AndroidImportance.MAX,
-      vibrationPattern: [0, 250, 250, 250],
-      lightColor: "#FF231F7C",
-    });
-  }
-
-  if (Device.isDevice) {
-    // 권한 받기
-    const { status: existingStatus } =
-      await Notifications.getPermissionsAsync();
-    let finalStatus = existingStatus;
-    if (existingStatus !== "granted") {
-      const { status } = await Notifications.requestPermissionsAsync();
-      finalStatus = status;
-    }
-    if (finalStatus !== "granted") {
-      handleRegistrationError("푸시 알림 권한 설정이 필요합니다!");
-      return;
-    }
-
-    const projectId =
-      Constants?.expoConfig?.extra?.eas?.projectId ??
-      Constants?.easConfig?.projectId;
-    if (!projectId) {
-      handleRegistrationError("Project ID를 찾을 수 없습니다");
-    }
-
-    try {
-      const pushTokenString = (
-        await Notifications.getExpoPushTokenAsync({ projectId })
-      ).data;
-      return pushTokenString;
-    } catch (e: unknown) {
-      handleRegistrationError(`${e}`);
-    }
-  } else {
-    handleRegistrationError("Must use physical device for push notifications");
-  }
 }

--- a/providers/notificationProvider.tsx
+++ b/providers/notificationProvider.tsx
@@ -118,6 +118,7 @@ export default function NotificationProvider({ children }: Props) {
     const handlePermissionChange = async () => {
       const { status } = await Notifications.getPermissionsAsync();
       if (status === pushPermission || !session) return;
+      setPushPermission(status);
 
       const userId = session.user.id;
       if (status === "granted") {
@@ -126,8 +127,6 @@ export default function NotificationProvider({ children }: Props) {
         await resetPushSetting(userId);
         handleUpdate();
       }
-
-      setPushPermission(status);
     };
 
     // 앱이 foreground 로 돌아왔을 때 권한변경 감지

--- a/types/Friend.interface.ts
+++ b/types/Friend.interface.ts
@@ -10,7 +10,7 @@ export type RelationType = (typeof RELATION_TYPE)[keyof typeof RELATION_TYPE];
 
 export interface RequestInfo {
   requestId: number;
-  toUserId: string;
+  toUser: UserProfile;
   fromUser: UserProfile;
 }
 

--- a/types/Notification.interface.ts
+++ b/types/Notification.interface.ts
@@ -12,11 +12,12 @@ export type NotificationType =
   (typeof NOTIFICATION_TYPE)[keyof typeof NOTIFICATION_TYPE];
 
 export interface NotificationData {
-  postId: number;
+  postId?: number;
   commentInfo?: {
     id: number;
     content?: string;
   };
+  isAccepted?: boolean;
 }
 
 export interface Notification {

--- a/types/Notification.interface.ts
+++ b/types/Notification.interface.ts
@@ -34,15 +34,15 @@ export interface NotificationResponse {
   createdAt: string;
 }
 
-export interface PushToken {
+export interface PushSetting {
   userId: string;
-  pushToken: string | null;
+  token: string | null;
   grantedNotifications: NotificationType[];
 }
 
-export interface PushTokenUpdateData {
+export interface PushSettingUpdateData {
   userId: string;
-  pushToken?: string | null;
+  token?: string | null;
   grantedNotifications?: NotificationType[];
 }
 

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -380,6 +380,12 @@ export type Database = {
         };
         Returns: undefined;
       };
+      delete_user_data: {
+        Args: {
+          user_id: string;
+        };
+        Returns: undefined;
+      };
       get_comments: {
         Args: {
           postid: number;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -266,21 +266,21 @@ export type Database = {
           createdAt: string;
           grantedNotifications: Database["public"]["Enums"]["notificationtype"][];
           id: number;
-          pushToken: string | null;
+          token: string | null;
           userId: string;
         };
         Insert: {
           createdAt?: string;
           grantedNotifications: Database["public"]["Enums"]["notificationtype"][];
           id?: number;
-          pushToken: string | null;
+          token: string | null;
           userId: string;
         };
         Update: {
           createdAt?: string;
           grantedNotifications?: Database["public"]["Enums"]["notificationtype"][];
           id?: number;
-          pushToken?: string | null;
+          token?: string | null;
           userId?: string;
         };
         Relationships: [

--- a/utils/formMessage.ts
+++ b/utils/formMessage.ts
@@ -4,17 +4,26 @@ import {
 } from "@/types/Notification.interface";
 
 const COMMENT_MAX_LENGTH = 18;
+
 export const shorten_comment = (
   comment: string,
   maxLength = COMMENT_MAX_LENGTH,
 ) =>
   `"${comment.length > maxLength ? comment.slice(0, maxLength).concat("...") : comment}"`;
 
-export function formMessage(
-  type: NotificationType,
-  username?: string,
-  comment?: string,
-) {
+interface FormMessageProps {
+  type: NotificationType;
+  username?: string;
+  comment?: string;
+  isAccepted?: boolean;
+}
+
+export function formMessage({
+  type,
+  username,
+  comment,
+  isAccepted,
+}: FormMessageProps) {
   const NOTIFICATION_CONFIG = {
     [NOTIFICATION_TYPE.POKE]: {
       title: "👈 콕!",
@@ -35,6 +44,12 @@ export function formMessage(
     [NOTIFICATION_TYPE.LIKE]: {
       title: `${username}님이`,
       content: "게시글에 좋아요를 눌렀어요❤️",
+    },
+    [NOTIFICATION_TYPE.FRIEND]: {
+      title: `${username}님이`,
+      content: isAccepted
+        ? "친구 요청을 수락하셨어요😊"
+        : "친구 요청을 보냈어요",
     },
   };
 

--- a/utils/pushTokenManager.ts
+++ b/utils/pushTokenManager.ts
@@ -132,11 +132,6 @@ async function registerForPushNotificationsAsync(
       finalStatus = status;
     }
     if (finalStatus !== "granted") {
-      if (retry) {
-        handleRegistrationError("푸시 알림 권한 설정이 필요합니다!");
-        // TODO 가능하다면 설정 창으로 이동
-        // Linking.openURL("app-settings:");
-      }
       return null;
     }
 

--- a/utils/pushTokenManager.ts
+++ b/utils/pushTokenManager.ts
@@ -1,0 +1,54 @@
+import Constants from "expo-constants";
+import * as Device from "expo-device";
+import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
+
+function handleRegistrationError(errorMessage: string) {
+  alert(errorMessage);
+  throw new Error(errorMessage);
+}
+
+export async function registerForPushNotificationsAsync() {
+  // 안드로이드 알림 설정
+  if (Platform.OS === "android") {
+    Notifications.setNotificationChannelAsync("default", {
+      name: "default",
+      importance: Notifications.AndroidImportance.MAX,
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: "#FF231F7C",
+    });
+  }
+
+  if (Device.isDevice) {
+    // 권한 받기
+    const { status: existingStatus } =
+      await Notifications.getPermissionsAsync();
+    let finalStatus = existingStatus;
+    if (existingStatus !== "granted") {
+      const { status } = await Notifications.requestPermissionsAsync();
+      finalStatus = status;
+    }
+    if (finalStatus !== "granted") {
+      handleRegistrationError("푸시 알림 권한 설정이 필요합니다!");
+      return;
+    }
+
+    const projectId =
+      Constants?.expoConfig?.extra?.eas?.projectId ??
+      Constants?.easConfig?.projectId;
+    if (!projectId) {
+      handleRegistrationError("Project ID를 찾을 수 없습니다");
+    }
+
+    try {
+      const pushTokenString = (
+        await Notifications.getExpoPushTokenAsync({ projectId })
+      ).data;
+      return pushTokenString;
+    } catch (e: unknown) {
+      handleRegistrationError(`${e}`);
+    }
+  } else {
+    handleRegistrationError("Must use physical device for push notifications");
+  }
+}

--- a/utils/pushTokenManager.ts
+++ b/utils/pushTokenManager.ts
@@ -47,14 +47,7 @@ export async function addPushToken({
     handleUpdate();
     return true;
   } catch (error) {
-    if (error instanceof Error && error.message) {
-      await createPushSetting({
-        userId,
-        token: error.message,
-        grantedNotifications: [],
-      });
-      handleUpdate();
-    }
+    console.error(error);
   }
 
   return false;
@@ -69,14 +62,15 @@ export async function updatePushToken({
 }: UpdatePushTokenProps): Promise<boolean> {
   try {
     const token = await registerForPushNotificationsAsync(retry);
-    if (isTokenValid(token) && token !== existingToken) {
+    if (token !== existingToken && isTokenValid(token)) {
       await updatePushSetting({ userId, token });
       handleUpdate();
       return true;
     }
   } catch (error) {
-    if (error instanceof Error && error.message) {
-      await updatePushSetting({ userId, token: error.message });
+    if (error) {
+      await updatePushSetting({ userId, token: null });
+      console.error(error);
       handleUpdate();
     }
   }
@@ -114,7 +108,7 @@ async function registerForPushNotificationsAsync(
   retry = false,
 ): Promise<string | null> {
   // 안드로이드 알림 설정
-  if (Platform.OS === "android") {
+  if (!retry && Platform.OS === "android") {
     Notifications.setNotificationChannelAsync("default", {
       name: "default",
       importance: Notifications.AndroidImportance.MAX,

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1381,7 +1381,6 @@ export async function createPushToken(pushTokenData: PushToken) {
 
   if (error) {
     console.error("푸시 알림 정보 저장 실패:", error);
-    throw new Error("푸시 알림 정보 저장에 실패했습니다.");
   }
 }
 

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1334,7 +1334,7 @@ export async function createNotification(notification: Notification) {
       body: message.content,
       data: notification.data,
     };
-    sendPushNotification(pushMessage);
+    await sendPushNotification(pushMessage);
   } catch (error) {
     console.error("푸시 알림 생성에 실패했습니다.", error);
   }
@@ -1342,7 +1342,7 @@ export async function createNotification(notification: Notification) {
 
 // 푸시 알림 보내기
 async function sendPushNotification(message: PushMessage) {
-  await fetch("https://exp.host/--/api/v2/push/send", {
+  const response = await fetch("https://exp.host/--/api/v2/push/send", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${expoPushToken}`,
@@ -1352,6 +1352,13 @@ async function sendPushNotification(message: PushMessage) {
     },
     body: JSON.stringify(message),
   });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(
+      `푸시 알림 전송 실패: ${error.message || response.statusText}`,
+    );
+  }
 }
 
 // ============================================

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1411,6 +1411,10 @@ export async function updatePushSetting({
   }
 }
 
+export async function resetPushSetting(userId: string) {
+  await updatePushSetting({ userId, token: null, grantedNotifications: [] });
+}
+
 // ============================================
 //
 //                    type

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1004,7 +1004,7 @@ export async function getFriendRequests(
       `
           id,
           from: user!friendRequest_from_fkey (id, username, avatarUrl, description),
-          to
+          to: user!friendRequest_to_fkey (id, username, avatarUrl, description)
         `,
       { count: "exact" },
     )
@@ -1019,7 +1019,7 @@ export async function getFriendRequests(
   return {
     data: data.map((request) => ({
       requestId: request.id,
-      toUserId: request.to,
+      toUser: request.to as UserProfile,
       fromUser: request.from as UserProfile,
     })),
     total: count || 0,
@@ -1322,11 +1322,12 @@ export async function createNotification(notification: Notification) {
     if (!data || !data.token) return;
     if (!data.grantedNotifications.includes(notification.type)) return;
 
-    const message = formMessage(
-      notification.type,
-      notification.from.username,
-      notification.data?.commentInfo?.content,
-    );
+    const message = formMessage({
+      type: notification.type,
+      username: notification.from.username,
+      comment: notification.data?.commentInfo?.content,
+      isAccepted: notification.data?.isAccepted,
+    });
     const pushMessage = {
       to: data.token,
       sound: "default",

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1382,9 +1382,7 @@ export async function getPushToken(userId: string): Promise<PushToken | null> {
 
 // 푸시 알림 설정 추가
 export async function createPushToken(pushTokenData: PushToken) {
-  const { error } = await supabase
-    .from("pushToken")
-    .upsert(pushTokenData, { onConflict: "userId" });
+  const { error } = await supabase.from("pushToken").insert(pushTokenData);
 
   if (error) {
     console.error("푸시 알림 정보 저장 실패:", error);
@@ -1392,18 +1390,18 @@ export async function createPushToken(pushTokenData: PushToken) {
 }
 
 // 푸시 알림 설정 업데이트
-export async function updatePushToken(pushTokenData: PushTokenUpdateData) {
+export async function updatePushToken({
+  userId,
+  pushToken,
+  grantedNotifications,
+}: PushTokenUpdateData) {
   const { error } = await supabase
     .from("pushToken")
     .update({
-      ...(pushTokenData.pushToken === undefined
-        ? {}
-        : { pushToken: pushTokenData.pushToken }),
-      ...(pushTokenData.grantedNotifications === undefined
-        ? {}
-        : { grantedNotifications: pushTokenData.grantedNotifications }),
+      ...(pushToken === undefined ? {} : { pushToken }),
+      ...(grantedNotifications === undefined ? {} : { grantedNotifications }),
     })
-    .eq("userId", pushTokenData.userId);
+    .eq("userId", userId);
 
   if (error) {
     console.error("푸시 알림 정보 저장 실패:", error);


### PR DESCRIPTION
## 📝 PR 설명
푸시 알림 권한 설정과 알림 on/off 관련하여 이슈에 작성한 시나리오에 맞게 동작하도록 했고, 리팩토링했습니다.

## 🔍 변경사항
- 권한 설정 시나리오에 맞는 동작 구현
  - 앱에 처음 로그인 시 권한 물어보기
  - 로그인시 앱에 기기 알림설정 있으면 토큰 저장
  - 로그아웃시 토큰 null로 변경
  - 초기 설정은 기기 알림설정 O -> all, X -> none이고, 알림설정 페이지에서 변경한 뒤 페이지를 벗어날 때 저장
  - 앱 최소화하고 푸시알림 설정 변경 시 변경사항 반영
  - 알림 차단된 상태에서 알림설정 키려고 하면 설정 페이지로 이동 유도
- 리팩토링 진행
  - pushTokenManager: 푸시 알림 토큰 관련 함수들을 제공
  - NotificationProvider: 실제로 전역에서 토큰을 관리
  - app/settings.js의 NotificationSetting: 개별 알림 설정 변경
- DB에서 pushToken -> token으로 column 이름 변경
- 친구요청 푸시알림 추가
- 좋아요 푸시알림 -> 게시글 좋아요 + 댓글 좋아요

## 🔗 관련 이슈
- close #89 
- close #90
- close #93

## 📌 기타 참고사항
다양한 시나리오에서 제대로 동작하는지 확인 부탁드립니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- 알림 설정 관리 기능이 개선되었습니다.
	- 로딩 화면이 추가되어 푸시 설정을 가져오는 동안 사용자에게 피드백을 제공합니다.
	- 알림 설정을 위한 새로운 컴포넌트가 도입되었습니다.
	- 친구 요청 및 사용자 관계 관리를 위한 기능이 향상되었습니다.
	- 푸시 알림 관리 시스템이 개선되어 새로운 기능이 추가되었습니다.
	- `formMessage` 함수가 객체 구조를 사용하여 매개변수를 처리하도록 변경되었습니다.

- **버그 수정**
	- 푸시 토큰 관리 로직이 간소화되어 오류 처리 및 상태 관리를 개선했습니다.

- **문서화**
	- 푸시 알림 관련 인터페이스 및 메서드 이름이 변경되어 일관성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->