### PR TITLE
refactor: 폼형태 유효성 검사 로직 리팩토링 및 회원가입 로직 수정

### DIFF
--- a/app/(auth)/sign-up/step1.tsx
+++ b/app/(auth)/sign-up/step1.tsx
@@ -143,7 +143,7 @@ const Step1 = () => {
         visible={isModalVisible}
         onClose={() => {
           setIsModalVisible(false);
-          router.push("/sign-up/step2");
+          router.replace("/sign-up/step2");
         }}
         position="middle"
       >
@@ -158,7 +158,7 @@ const Step1 = () => {
               className="mt-5 h-[62px] w-full items-center justify-center rounded-[10px] bg-primary"
               onPress={() => {
                 setIsModalVisible(false);
-                router.push("/sign-up/step2");
+                router.replace("/sign-up/step2");
               }}
             >
               <Text className="title-2 text-white">확인</Text>

--- a/app/(auth)/sign-up/step1.tsx
+++ b/app/(auth)/sign-up/step1.tsx
@@ -1,6 +1,7 @@
 import CustomModal from "@/components/Modal";
 import Icons from "@/constants/icons";
-import { sendUpOTP, supabase } from "@/utils/supabase";
+import { sendUpOTP } from "@/utils/supabase";
+import { validateSignUpFormWithSupabase } from "@/utils/validation";
 import images from "@constants/images";
 import { signUpFormAtom } from "@contexts/auth";
 import { useRouter } from "expo-router";
@@ -31,50 +32,15 @@ const Step1 = () => {
 
     setIsLoading(true);
     try {
-      const { data: userData, error: userError } = await supabase
-        .from("user")
-        .select("isOAuth, email")
-        .eq("email", signUpForm.email)
-        .single();
+      const validationError = await validateSignUpFormWithSupabase(
+        signUpForm.email,
+        signUpForm.username,
+        signUpForm.password,
+        passwordConfirm,
+      );
 
-      if (
-        !signUpForm.email ||
-        !signUpForm.username ||
-        !signUpForm.password ||
-        !passwordConfirm
-      ) {
-        Alert.alert("빈칸을 채워주세요.");
-        return;
-      }
-
-      if (signUpForm.username.length < 3) {
-        Alert.alert("닉네임은 3자 이상이어야 합니다.");
-        return;
-      }
-
-      if (signUpForm.password !== passwordConfirm) {
-        Alert.alert("비밀번호가 일치하지 않습니다.");
-        return;
-      }
-
-      if (signUpForm.password.length < 8 || passwordConfirm.length < 8) {
-        Alert.alert("비밀번호는 8자 이상이어야 합니다.");
-        return;
-      }
-
-      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-      if (!emailRegex.test(signUpForm.email)) {
-        Alert.alert("알림", "올바른 이메일 형식이 아닙니다.");
-        return;
-      }
-
-      if (userData?.isOAuth) {
-        Alert.alert("알림", "소셜 로그인으로 가입된 계정입니다.");
-        return;
-      }
-
-      if (userData?.email) {
-        Alert.alert("알림", "이미 가입된 이메일입니다.");
+      if (validationError) {
+        Alert.alert("알림", validationError.message);
         return;
       }
 

--- a/app/(auth)/sign-up/step2.tsx
+++ b/app/(auth)/sign-up/step2.tsx
@@ -50,6 +50,13 @@ const Step2 = () => {
         description: signUpForm.description,
       });
 
+      setSignUpForm({
+        email: "",
+        password: "",
+        username: "",
+        description: "",
+      });
+
       router.replace("/onboarding");
     } catch (error) {
       if (

--- a/app/(auth)/sign-up/step2.tsx
+++ b/app/(auth)/sign-up/step2.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/hooks/useTimer";
 import { formatTime } from "@/utils/formatTime";
 import { signUp, verifySignUpOTP } from "@/utils/supabase";
+import { validateStep2Form } from "@/utils/validation";
 import images from "@constants/images";
 import { signUpFormAtom } from "@contexts/auth";
 import { useRouter } from "expo-router";
@@ -33,8 +34,9 @@ const Step2 = () => {
   const handleSignUp = async () => {
     if (isLoading) return;
 
-    if (!signUpForm.username) {
-      Alert.alert("닉네임을 채워주세요");
+    const validationError = validateStep2Form(signUpForm.username, otpcode);
+    if (validationError) {
+      Alert.alert("알림", validationError.message);
       return;
     }
 

--- a/contexts/auth.ts
+++ b/contexts/auth.ts
@@ -4,7 +4,6 @@ interface SignUpForm {
   email: string;
   password: string;
   username: string;
-  avatar: string;
   description?: string;
 }
 
@@ -16,7 +15,6 @@ export const signUpFormAtom = atom<SignUpForm>({
   email: "",
   password: "",
   username: "",
-  avatar: "",
   description: "",
 });
 

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -2,7 +2,7 @@ import { supabase } from "./supabase";
 
 export interface SignUpValidationError {
   message: string;
-  field: "email" | "username" | "password" | "passwordConfirm";
+  field: "email" | "username" | "password" | "passwordConfirm" | "otpcode";
 }
 
 export const validateEmail = (email: string): SignUpValidationError | null => {
@@ -132,6 +132,29 @@ export const validateSignUpFormWithSupabase = async (
   // Supabase 이메일 검증
   const supabaseValidationError = await validateEmailWithSupabase(email);
   if (supabaseValidationError) return supabaseValidationError;
+
+  return null;
+};
+
+export const validateOTPCode = (
+  otpcode: string,
+): SignUpValidationError | null => {
+  if (!otpcode) {
+    return { message: "인증코드를 입력해주세요.", field: "otpcode" };
+  }
+
+  return null;
+};
+
+export const validateStep2Form = (
+  username: string,
+  otpcode: string,
+): SignUpValidationError | null => {
+  const usernameError = validateUsername(username);
+  if (usernameError) return usernameError;
+
+  const otpError = validateOTPCode(otpcode);
+  if (otpError) return otpError;
 
   return null;
 };

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -1,0 +1,137 @@
+import { supabase } from "./supabase";
+
+export interface SignUpValidationError {
+  message: string;
+  field: "email" | "username" | "password" | "passwordConfirm";
+}
+
+export const validateEmail = (email: string): SignUpValidationError | null => {
+  if (!email) {
+    return { message: "이메일을 입력해주세요.", field: "email" };
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return { message: "올바른 이메일 형식이 아닙니다.", field: "email" };
+  }
+
+  return null;
+};
+
+export const validateUsername = (
+  username: string,
+): SignUpValidationError | null => {
+  if (!username) {
+    return { message: "닉네임을 입력해주세요.", field: "username" };
+  }
+
+  if (username.length < 3) {
+    return { message: "닉네임은 3자 이상이어야 합니다.", field: "username" };
+  }
+
+  return null;
+};
+
+export const validatePassword = (
+  password: string,
+): SignUpValidationError | null => {
+  if (!password) {
+    return { message: "비밀번호를 입력해주세요.", field: "password" };
+  }
+
+  if (password.length < 8) {
+    return { message: "비밀번호는 8자 이상이어야 합니다.", field: "password" };
+  }
+
+  return null;
+};
+
+export const validatePasswordConfirm = (
+  password: string,
+  passwordConfirm: string,
+): SignUpValidationError | null => {
+  if (!passwordConfirm) {
+    return {
+      message: "비밀번호 확인을 입력해주세요.",
+      field: "passwordConfirm",
+    };
+  }
+
+  if (password !== passwordConfirm) {
+    return {
+      message: "비밀번호가 일치하지 않습니다.",
+      field: "passwordConfirm",
+    };
+  }
+
+  return null;
+};
+
+export const validateSignUpForm = (
+  email: string,
+  username: string,
+  password: string,
+  passwordConfirm: string,
+): SignUpValidationError | null => {
+  const emailError = validateEmail(email);
+  if (emailError) return emailError;
+
+  const usernameError = validateUsername(username);
+  if (usernameError) return usernameError;
+
+  const passwordError = validatePassword(password);
+  if (passwordError) return passwordError;
+
+  const passwordConfirmError = validatePasswordConfirm(
+    password,
+    passwordConfirm,
+  );
+  if (passwordConfirmError) return passwordConfirmError;
+
+  return null;
+};
+
+export const validateEmailWithSupabase = async (
+  email: string,
+): Promise<SignUpValidationError | null> => {
+  const emailError = validateEmail(email);
+  if (emailError) return emailError;
+
+  const { data: userData, error: userError } = await supabase
+    .from("user")
+    .select("isOAuth, email")
+    .eq("email", email)
+    .single();
+
+  if (userData?.isOAuth) {
+    return { message: "소셜 로그인으로 가입된 계정입니다.", field: "email" };
+  }
+
+  if (userData?.email) {
+    return { message: "이미 가입된 이메일입니다.", field: "email" };
+  }
+
+  return null;
+};
+
+export const validateSignUpFormWithSupabase = async (
+  email: string,
+  username: string,
+  password: string,
+  passwordConfirm: string,
+): Promise<SignUpValidationError | null> => {
+  // 기본 유효성 검사
+  const basicValidationError = validateSignUpForm(
+    email,
+    username,
+    password,
+    passwordConfirm,
+  );
+  if (basicValidationError) return basicValidationError;
+
+  // Supabase 이메일 검증
+  const supabaseValidationError = await validateEmailWithSupabase(email);
+  if (supabaseValidationError) return supabaseValidationError;
+
+  return null;
+};


### PR DESCRIPTION
## 📝 PR 설명
<!-- PR에 대한 설명을 작성해주세요 -->

- 폼형태 특성상 유효성 검사 로직이 너무 길어져 따로 분리하였습니다

- 어제 예하님과 대화하고 나서 회원가입 놓친부분이 없나 고민했는데
    1. otp입력 페이지에서 뒤로가기를 누르면 어떤 페이지로 가야하는가?
        1. 첫 회원가입 페이지 (step1)
        2. 로그인 페이지
        두가지로 나뉘는데 otp입력에서 뒤로 갈 경우는 OAuth로 다시 입력하거나 이미 로그인한 계정이 있을때의 시나리오 이외가 떠오르지 않아 step2가는 로직을 replace로 바꾸었습니다. 이 때 다시 회원가입(step1)으로 돌아가면 필드를 비워야하는가?에 대한 고민도 해보았는데 올바르게 비밀번호를 친게 맞는지 확인하기 위해 confirm만 비우고 나머지는 다시 돌아가도 있도록 했습니다. confirm도 굳이 비워야되는지 모르겠다면 전역상태로 바꿔서 유지하겠습니다!

    2. 전역상태로 회원가입 로직을 관리하면서 놓친점
        1. 성공했을때 입력했던 필드를 비워야함(버그 가능성 + 다시 회원가입 했을 때 빈 필드로 유지하기 위함)

    3. 결론
        - 회원가입 step1에서 step2로 넘어가는 부분을 replace로 바꾸어 otp입력페이지에서 뒤로갈 때 회원가입으로 넘어가도록 구현(안드로이드는 확인 필요)
        - 회원가입으로 넘어가고 다시 회원가입할 때 비밀번호 확인만 비움(진짜 입력했었던 메일,닉네임, 비밀번호로 회원가입 할 것인지 체크용)
        - 회원가입 성공 시 로그인을 위한 전역상태 비움(pushToken에러로 잘 되는지 확인은 못했으나 로직상 문제없다 판단)