### PR TITLE
refactor: 댓글 삭제 기능 수정

### DIFF
--- a/components/MotionModal.tsx
+++ b/components/MotionModal.tsx
@@ -187,7 +187,7 @@ export default function MotionModal({
                 className="h-full flex-1 rounded-t-[20px] border border-gray-20 bg-white"
               >
                 <View
-                  className="w-full items-center py-2.5"
+                  className="w-full items-center py-4"
                   {...panResponder.panHandlers}
                 >
                   <View className="h-1 w-10 rounded-[2px] bg-gray-25" />

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -249,6 +249,17 @@ export default function CommentItem({
             </TouchableOpacity>
           )}
 
+          {/* kebab button */}
+          {author?.id === user.data?.id && (
+            <TouchableOpacity onPress={handleOpenModal} className="ml-2">
+              <Icons.KebabMenuIcon
+                width={24}
+                height={24}
+                color={colors.black}
+              />
+            </TouchableOpacity>
+          )}
+
           <CustomModal
             visible={isModalVisible}
             onClose={handleCloseModal}

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -165,7 +165,13 @@ export default function CommentItem({
   );
 
   return (
-    <Pressable onLongPress={handleOpenModal}>
+    <Pressable
+      onLongPress={() => {
+        if (author?.id === user.data?.id) {
+          handleOpenModal();
+        }
+      }}
+    >
       {/* header */}
       <View className="flex-row items-center justify-between pb-[13px]">
         {/* user info */}
@@ -268,7 +274,11 @@ export default function CommentItem({
           onPress={() =>
             contents.length > calculateMaxChars && setIsTextMore(!isTextMore)
           }
-          onLongPress={handleOpenModal}
+          onLongPress={() => {
+            if (author?.id === user.data?.id) {
+              handleOpenModal();
+            }
+          }}
           className="title-5 flex-1 text-gray-90"
         >
           {isReply && replyTo?.username && (

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -22,6 +22,7 @@ import { useCallback, useState } from "react";
 import {
   ActivityIndicator,
   Image,
+  Pressable,
   Text,
   TouchableOpacity,
   View,
@@ -80,10 +81,12 @@ export default function CommentItem({
   const [isLiked, setIsLiked] = useState(liked);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isTextMore, setIsTextMore] = useState(false);
-  const queryClient = useQueryClient();
-
   const { truncateText, calculateMaxChars } = useTruncateText();
+
+  const queryClient = useQueryClient();
   const router = useRouter();
+
+  const diff = diffDate(new Date(createdAt));
 
   // 답글 가져오기
   const {
@@ -111,10 +114,15 @@ export default function CommentItem({
     }
   }, [replyHasNextPage, isReplyFetchingNextPage, replyFetchNextPage]);
 
-  const toggleModal = () => {
-    setIsModalVisible((prev) => !prev);
-  };
+  const handleOpenModal = useCallback(() => {
+    setIsModalVisible(true);
+  }, []);
 
+  const handleCloseModal = useCallback(() => {
+    setIsModalVisible(false);
+  }, []);
+
+  // 좋아요 토글
   const toggleLike = useMutation({
     mutationFn: () => toggleLikeComment(id),
     onMutate: () => {
@@ -133,6 +141,7 @@ export default function CommentItem({
     },
   });
 
+  // 좋아요 알림
   const sendNotificationMutation = useMutation<void, Error, UserProfile>({
     mutationFn: (from) =>
       createNotification({
@@ -148,16 +157,15 @@ export default function CommentItem({
       }),
   });
 
+  // 현재 사용자 정보
   const user = useFetchData(
     ["currentUser"],
     getCurrentUser,
     "사용자 정보를 불러오는데 실패했습니다.",
   );
 
-  const diff = diffDate(new Date(createdAt));
-
   return (
-    <View>
+    <Pressable onLongPress={handleOpenModal}>
       {/* header */}
       <View className="flex-row items-center justify-between pb-[13px]">
         {/* user info */}
@@ -235,34 +243,23 @@ export default function CommentItem({
             </TouchableOpacity>
           )}
 
-          {/* kebab menu */}
-          {user.data?.id === author?.id && (
-            <TouchableOpacity onPress={toggleModal} className="ml-2">
-              <Icons.KebabMenuIcon
-                width={24}
-                height={24}
-                color={colors.black}
-              />
-
-              <CustomModal
-                visible={isModalVisible}
-                onClose={toggleModal}
-                position="bottom"
+          <CustomModal
+            visible={isModalVisible}
+            onClose={handleCloseModal}
+            position="bottom"
+          >
+            <View className="items-center">
+              <TouchableOpacity
+                onPress={() => {
+                  onDeletedPress(id);
+                  handleCloseModal();
+                }}
+                className="h-[82px] w-full items-center justify-center"
               >
-                <View className="items-center">
-                  <TouchableOpacity
-                    onPress={() => {
-                      onDeletedPress(id);
-                      toggleModal();
-                    }}
-                    className="h-[82px] w-full items-center justify-center"
-                  >
-                    <Text className="title-2 text-gray-90">삭제하기</Text>
-                  </TouchableOpacity>
-                </View>
-              </CustomModal>
-            </TouchableOpacity>
-          )}
+                <Text className="title-2 text-gray-90">삭제하기</Text>
+              </TouchableOpacity>
+            </View>
+          </CustomModal>
         </View>
       </View>
       {/* contents */}
@@ -271,6 +268,7 @@ export default function CommentItem({
           onPress={() =>
             contents.length > calculateMaxChars && setIsTextMore(!isTextMore)
           }
+          onLongPress={handleOpenModal}
           className="title-5 flex-1 text-gray-90"
         >
           {isReply && replyTo?.username && (
@@ -284,21 +282,22 @@ export default function CommentItem({
           )}
         </Text>
       </View>
+
       {/* reply button */}
       <TouchableOpacity
-        className={isReply ? "pb-[5px]" : "pb-[13px]"}
+        className={`${isReply ? "pb-[5px]" : "pb-[13px]"} self-start`}
         onPress={() => {
           if (author) {
             onReply(author.id, author.username, parentsCommentId ?? id, id);
           }
         }}
       >
-        <Text className="caption-2 text-gray-60">답글달기</Text>
+        <Text className="caption-2 w-20 text-gray-60 ">답글달기</Text>
       </TouchableOpacity>
 
       {/* reply */}
       {!!totalReplies && totalReplies > 0 && (
-        <View className="px-4">
+        <View className="pl-4">
           {!!replyData && (
             <FlatList
               className="gap-2"
@@ -359,8 +358,9 @@ export default function CommentItem({
             )}
         </View>
       )}
+
       {/* divider */}
       {!isReply && <View className="mt-2 mb-4 h-[1px] w-full bg-gray-20" />}
-    </View>
+    </Pressable>
   );
 }

--- a/components/comments/CommentsSection.tsx
+++ b/components/comments/CommentsSection.tsx
@@ -65,13 +65,11 @@ export default function CommentsSection({
   const [selectedCommentId, setSelectedCommentId] = useState<number | null>(
     null,
   );
-
   const [isLikedModalVisible, setIsLikedModalVisible] = useState(false);
   const [likedAuthorId, setLikedAuthorId] = useState<number | null>(null);
 
   const queryClient = useQueryClient();
   const inputRef = useRef<TextInput>(null);
-
   const router = useRouter();
 
   const { data: likedAuthor } = useFetchData(


### PR DESCRIPTION
## 📝 PR 설명
~~현재 댓글 삭제는 댓글 우측의 케밥 버튼을 눌러 진행하는 방식입니다. 그러나 이 방식이 댓글 디자인을 해친다는 의견이 있어 수정이 필요하다는 이야기가 나오게 되었습니다.~~
-> 이런 이야기 없었고 우측 패딩만 지우는 거였네요

그래서 이 방식을 댓글을 길게 터치하여 모달의 띄우는 형식으로 수정하였습니다.

댓글창 최상단에 longPress를 추가했지만, 하위 컴포넌트로 이벤트 전달이되지 않아 현재는 댓글 내용 부분과 빈 공간을 길게 터치했을 때 모달이 나타나도록 구현했습니다.

+ 추가로 답글의 우측 패딩을 지웠습니다.

- close #101 

## 🔍 변경사항
- 댓글창을 꾹 터치 시 하단의 삭제하기 모달을 띄움

## 📸 스크린샷

삭제 모달|답글 수정
---|---
![Screenshot 2024-12-16 at 20 25 35](https://github.com/user-attachments/assets/44abf8ae-70b8-4999-8053-0e147c0e680d)|![image](https://github.com/user-attachments/assets/e8664b92-5af7-4df0-ad2d-3692a6e7a27c)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 모달의 스타일이 개선되어 콘텐츠의 수직 여백이 증가했습니다.
  - 댓글 항목에서 긴 눌림 상호작용을 지원하는 `Pressable` 컴포넌트 사용.
  - 댓글 좋아요 시 알림 기능 추가.
  - 댓글 작성 시 알림 전송 로직 개선.
  - 댓글 삭제 시 사용자 피드백을 위한 오류 처리 추가.
  - 데이터 로딩 및 빈 상태를 효과적으로 처리하는 렌더링 로직 개선.

- **버그 수정**
  - 댓글 섹션 닫기 시 쿼리 제거 로직 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->