### PR TITLE
feat: 게시글 이미지 더블 터치 시 좋아요 기능 추가

### DIFF
--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -1,12 +1,23 @@
-import { View, FlatList, Image, Dimensions } from "react-native";
-import { useState, useCallback, useMemo } from "react";
+import colors from "@/constants/colors";
+import Icons from "@/constants/icons";
+import { useCallback, useMemo, useState } from "react";
+import {
+  Dimensions,
+  FlatList,
+  Image,
+  TouchableWithoutFeedback,
+  View,
+} from "react-native";
 import Animated, {
   useAnimatedStyle,
   withSpring,
+  withTiming,
 } from "react-native-reanimated";
 
 interface CarouselProps {
   images: string[];
+  onDoubleTap?: () => void;
+  showHeart?: boolean; // 추가
 }
 
 type ViewToken = {
@@ -14,11 +25,6 @@ type ViewToken = {
   key: string;
   index: number | null;
   isViewable: boolean;
-};
-
-const COLORS = {
-  ACTIVE: "#8356F5",
-  INACTIVE: "#BEBEBE",
 };
 
 interface DotProps {
@@ -35,8 +41,8 @@ const Dot = ({
   activeWidth = 24,
   inactiveWidth = 8,
   height = 8,
-  activeColor = COLORS.ACTIVE,
-  inactiveColor = COLORS.INACTIVE,
+  activeColor = colors.primary,
+  inactiveColor = colors.gray[40],
 }: DotProps) => {
   const animatedStyle = useAnimatedStyle(() => ({
     width: withSpring(isActive ? activeWidth : inactiveWidth),
@@ -49,7 +55,11 @@ const Dot = ({
   return <Animated.View style={animatedStyle} />;
 };
 
-export default function Carousel({ images }: CarouselProps) {
+export default function Carousel({
+  images,
+  onDoubleTap,
+  showHeart,
+}: CarouselProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const screenWidth = Dimensions.get("window").width;
   const imageHeight = screenWidth * (1 / 1); // n:n 비율 유지
@@ -70,22 +80,53 @@ export default function Carousel({ images }: CarouselProps) {
     [],
   );
 
+  let lastTap = 0;
+  const handleDoubleTap = () => {
+    if (!onDoubleTap) return;
+
+    const now = Date.now();
+    if (lastTap && now - lastTap < 300) onDoubleTap();
+    else lastTap = now;
+  };
+
+  const heartStyle = useAnimatedStyle(() => ({
+    opacity: withTiming(showHeart ? 0.8 : 0, { duration: 500 }),
+    transform: [{ scale: withSpring(showHeart ? 1 : 0.1) }],
+  }));
+
   return (
     <View>
       <FlatList
         data={images}
-        keyExtractor={(index) => `carousel-image-${index}`}
-        renderItem={({ item }) => (
-          <View style={{ width: screenWidth, height: imageHeight }}>
-            <Image
-              source={{ uri: item }}
-              style={{ width: "100%", height: "100%" }}
-              resizeMode="cover"
-              onError={(e) =>
-                console.error("Image loading error:", e.nativeEvent.error)
-              }
-            />
-          </View>
+        renderItem={({ item, index }) => (
+          <TouchableWithoutFeedback
+            onPress={handleDoubleTap}
+            key={`carousel-item-${index}-${item}`}
+          >
+            <View style={{ width: screenWidth, height: imageHeight }}>
+              <Image
+                source={{ uri: item }}
+                className="size-full"
+                resizeMode="cover"
+                onError={(e) =>
+                  console.error("Image loading error:", e.nativeEvent.error)
+                }
+              />
+
+              {/* heart animation */}
+              <Animated.View
+                className="absolute flex size-full items-center justify-center"
+                style={[heartStyle]}
+              >
+                <Icons.HeartIcon
+                  width={96}
+                  height={96}
+                  color={colors.white}
+                  fill={colors.white}
+                />
+              </Animated.View>
+            </View>
+          </TouchableWithoutFeedback>
         )}
         horizontal
         pagingEnabled
@@ -100,7 +141,10 @@ export default function Carousel({ images }: CarouselProps) {
 
       <View className="flex-row justify-center py-[10px]">
         {images.map((image, index) => (
-          <Dot key={`carousel-dot-${image}`} isActive={index === activeIndex} />
+          <Dot
+            key={`carousel-dot-${index}-${image}`}
+            isActive={index === activeIndex}
+          />
         ))}
       </View>
     </View>

--- a/components/PostItem.tsx
+++ b/components/PostItem.tsx
@@ -59,6 +59,7 @@ export default function PostItem({
   const [isLiked, setIsLiked] = useState(liked);
   const [isMore, setIsMore] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const [showHeart, setShowHeart] = useState(false);
   const queryClient = useQueryClient();
   const router = useRouter();
 
@@ -74,6 +75,14 @@ export default function PostItem({
     mutationFn: () => toggleLikePost(postId),
     onMutate: () => {
       setIsLiked((prev) => !prev);
+      if (!isLiked) {
+        setShowHeart(true);
+        setTimeout(() => {
+          setShowHeart(false);
+        }, 1000);
+      } else if (isLiked && showHeart) {
+        setShowHeart(false);
+      }
     },
     onSuccess: () => {
       if (user.data && isLiked && user.data?.id !== author.id) {
@@ -88,17 +97,6 @@ export default function PostItem({
     },
   });
 
-  const deletePostMutation = useMutation({
-    mutationFn: () => deletePost(postId),
-    onSuccess: () => {
-      showToast("success", "게시글이 삭제되었어요.");
-      queryClient.invalidateQueries({ queryKey: ["posts"] });
-    },
-    onError: () => {
-      showToast("fail", "게시글 삭제에 실패했어요.");
-    },
-  });
-
   const sendNotificationMutation = useMutation<void, Error, UserProfile>({
     mutationFn: (from) =>
       createNotification({
@@ -108,6 +106,10 @@ export default function PostItem({
         data: { postId },
       }),
   });
+
+  const onDoubleTap = () => {
+    if (!toggleLike.isPending && !isLiked) toggleLike.mutate();
+  };
 
   return (
     <View className="grow bg-white ">
@@ -174,7 +176,11 @@ export default function PostItem({
 
       {/* carousel */}
       <View className="h-max w-full bg-white pb-1">
-        <Carousel images={images} />
+        <Carousel
+          images={images}
+          onDoubleTap={onDoubleTap}
+          showHeart={showHeart}
+        />
       </View>
 
       {/* relation */}


### PR DESCRIPTION
## 📝 PR 설명
게시글 이미지 부분을 더블 터치하면 좋아요 가능하게 수정했고 게시글에 좋아요를 누르면 하트가 중앙에 나오게 만들었습니다.

## 🔍 변경사항
- 게시글 이미지 더블 터치 시 좋아요 기능 추가
- 게시글 좋아요 시 하트 아이콘 나오도록 추가

- 게시글 케러셀 key 중복 문제 수정

## 📸 스크린샷
![Screenshot 2024-12-17 at 16 48 43](https://github.com/user-attachments/assets/0f1f6f9d-e441-49c9-9df5-3f5f02e08ddd)


## 🔗 관련 이슈
- close #109 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- Carousel 컴포넌트에 더블탭 이벤트 핸들링을 위한 `onDoubleTap` 콜백 추가.
	- 포스트를 좋아요 할 때 하트 애니메이션을 표시하는 `showHeart` 프로퍼티 추가.
	- 포스트 아이템에서 더블탭으로 좋아요 토글 기능 추가.
- **버그 수정**
	- 포스트 삭제 관련 로직 제거 및 관리 방식 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->