### PR TITLE
fix: 알림설정 하위알림 우측여백 제거

### DIFF
--- a/app/(protected)/setting.tsx
+++ b/app/(protected)/setting.tsx
@@ -325,7 +325,7 @@ function NotificationSetting({
         />
       </View>
       {/* 개별 스위치 리스트 */}
-      <View className="gap-5 px-2">
+      <View className="gap-5 pl-2">
         {Object.keys(SWITCH_CONFIG).map((type) => (
           <View key={type} className="flex-row items-center justify-between">
             <Text className="font-pmedium text-gray-80 text-xl">


### PR DESCRIPTION
## 📝 PR 설명
마이페이지 -> 계정 설정의 알림 설정에서 하위 알림 설정들 양측 여백 -> 좌측여백으로 변경했습니다.

<img src="https://github.com/user-attachments/assets/86e78976-0170-4898-9447-c9cca5a8b2d9" width="300" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI 개선**
  - 알림 설정 UI의 패딩 조정으로 레이아웃 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->