### PR TITLE
fix: 세션 변화에 따른 리다이렉션 useAuthSession에서만 처리, 세션 변화하면 쿼리 초기화

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -2,9 +2,11 @@ import { Redirect, Stack } from "expo-router";
 
 import { Header, HeaderWithBack } from "@/components/Header";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { useQueryClient } from "@tanstack/react-query";
 
 const AuthLayout = () => {
-  const { session, isLoading } = useAuthSession();
+  const queryClient = useQueryClient();
+  const { session, isLoading } = useAuthSession(queryClient);
 
   if (isLoading) return null;
   if (session) return <Redirect href="/home" />;

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -100,8 +100,6 @@ const SignIn = () => {
           return;
         }
       }
-
-      router.replace("/home");
     }
   };
 
@@ -111,8 +109,6 @@ const SignIn = () => {
         email: userInput.email,
         password: userInput.password,
       });
-
-      router.replace("/home");
     } catch (error: unknown) {
       Alert.alert(
         "로그인 실패",

--- a/app/(protected)/_layout.tsx
+++ b/app/(protected)/_layout.tsx
@@ -1,10 +1,12 @@
 import { HeaderWithBack } from "@/components/Header";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { useQueryClient } from "@tanstack/react-query";
 import { Redirect } from "expo-router";
 import { Stack } from "expo-router";
 
 const ProtectedLayout = () => {
-  const { session, isLoading } = useAuthSession();
+  const queryClient = useQueryClient();
+  const { session, isLoading } = useAuthSession(queryClient);
 
   if (isLoading) return null;
   if (!session) return <Redirect href="/sign-in" />;

--- a/app/(protected)/setting.tsx
+++ b/app/(protected)/setting.tsx
@@ -65,8 +65,6 @@ export default function Setting() {
 
     try {
       await deleteUser(session?.user.id ?? "");
-
-      router.replace("/sign-in");
       showToast("success", "탈퇴가 완료되었습니다!");
     } catch (error) {
       showToast("error", "탈퇴에 실패했습니다.");
@@ -89,7 +87,6 @@ export default function Setting() {
 
       setIsLoading(false);
     }
-    queryClient.clear();
 
     setIsSignOutModalVisible(false);
     // 아마 세션 여부에 따른 리다이렉트 되면 자동 이동 될지도

--- a/app/(protected)/setting.tsx
+++ b/app/(protected)/setting.tsx
@@ -36,7 +36,6 @@ const NOTIFICATION_TYPE_GROUPS: { [key: string]: NotificationType[] } = {
 
 export default function Setting() {
   const router = useRouter();
-  const queryClient = useQueryClient();
 
   const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
   const [isSignOutModalVisible, setIsSignOutModalVisible] = useState(false);
@@ -89,8 +88,6 @@ export default function Setting() {
     }
 
     setIsSignOutModalVisible(false);
-    // 아마 세션 여부에 따른 리다이렉트 되면 자동 이동 될지도
-    router.replace("/sign-in");
     showToast("success", "로그아웃이 완료되었습니다!");
   };
 

--- a/hooks/useAuthSession.ts
+++ b/hooks/useAuthSession.ts
@@ -18,7 +18,6 @@ export function useAuthSession(queryClient: QueryClient) {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
-      console.log(session?.user.id);
       setSession(session);
       queryClient.clear();
     });

--- a/hooks/useAuthSession.ts
+++ b/hooks/useAuthSession.ts
@@ -1,8 +1,9 @@
 import { supabase } from "@/utils/supabase";
 import type { Session } from "@supabase/supabase-js";
+import type { QueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
-export function useAuthSession() {
+export function useAuthSession(queryClient: QueryClient) {
   const [session, setSession] = useState<Session | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -11,17 +12,21 @@ export function useAuthSession() {
       setSession(session);
       setIsLoading(false);
     });
+  }, []);
 
+  useEffect(() => {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
+      console.log(session?.user.id);
       setSession(session);
+      queryClient.clear();
     });
 
     return () => {
       subscription.unsubscribe();
     };
-  }, []);
+  }, [queryClient]);
 
   return { session, isLoading };
 }


### PR DESCRIPTION
## 📝 PR 설명
useAuthSession에서 세션 변화에 따라 /home, /sign-in으로 리다이렉트시키므로, 개별 컴포넌트에 있는 router.replace를 삭제했습니다. 또, 세션 변화할 때 쿼리도 초기화하도록 했습니다.

## 🔍 변경사항
- 개별 컴포넌트의 리다이렉트 코드 삭제
- useAuthSession에서 세션 변화 시 쿼리 초기화

## 🔗 관련 이슈
- close #111 
- close #105

테스트는 로그인 바뀔 때 화면 이동 잘 하는지, 각 탭에서 새로 로그인한 계정에 맞는 정보로 잘 로드되는지 확인해주시면 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- `useAuthSession` 훅이 `queryClient` 매개변수를 받도록 업데이트되었습니다.
	- `ProtectedLayout` 및 `AuthLayout`에서 `useQueryClient` 훅이 통합되었습니다.
  
- **Bug Fixes**
	- 로그인 후 홈으로의 자동 리디렉션 제거로 사용자 경험 개선.
  
- **Chores**
	- `handleSignOut`에서 `queryClient.clear()` 호출 제거로 로그아웃 프로세스 간소화.
	- `Setting` 컴포넌트에서 계정 삭제 후에만 로그인 페이지로 리디렉션하도록 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->