### PR TITLE
fix: 회원탈퇴 로그아웃

### DIFF
--- a/app/(protected)/setting.tsx
+++ b/app/(protected)/setting.tsx
@@ -66,7 +66,7 @@ export default function Setting() {
     try {
       await deleteUser(session?.user.id ?? "");
 
-      router.replace("/sign-in");
+      await supabase.auth.signOut();
       showToast("success", "탈퇴가 완료되었습니다!");
     } catch (error) {
       showToast("error", "탈퇴에 실패했습니다.");

--- a/app/(protected)/setting.tsx
+++ b/app/(protected)/setting.tsx
@@ -67,6 +67,8 @@ export default function Setting() {
       await deleteUser(session?.user.id ?? "");
 
       await supabase.auth.signOut();
+      queryClient.clear();
+
       showToast("success", "탈퇴가 완료되었습니다!");
     } catch (error) {
       showToast("error", "탈퇴에 실패했습니다.");


### PR DESCRIPTION
## 📝 PR 설명
<!-- PR에 대한 설명을 작성해주세요 -->

최대한 알아보았으나 이번년도 초부터 edge function을 쓰지 않아도 회원탈퇴 시 세션이 살아있었던 것 같습니다. [참고1](https://github.com/supabase/auth/issues/1550)

좋은 정보를 찾으려고 했는데 [edge function안에서 유저 제거하고 signOut썼는데도 안되는 사람들이 있었어서1](https://github.com/supabase/supabase-flutter/issues/1083) [안되는 사람 2 댓글은 document.cookie 직접 제거했다고 함](https://www.reddit.com/r/Supabase/comments/1c6fyfk/log_out_and_delete_from_authusers/) 저희는 맨 마지막에 signOut이 동작하여 그대로 적용시켰습니다.

혜원님이 찾아주신것도 봤는데 RLS관련 정보는 함부로 삭제하지 못하게 막아주라는 것으로 이해했고 user.id는 제약을 Authentication의 테이블이랑 연결시키면 좋을 것 같은데 auth.user라는 친구가 좀 다른 것 같아 필요할까 고민되긴 했습니다만 [supabase 튜토리얼에서는 제약을 걸고있어](https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs#set-up-the-database-schema) update, 제거 모두 cascade로 추가시켜 줬습니다. (관련 오류는 발견하지 못했는데 이상한점 있을 수 있으니 발견 시 말씀해주시면 감사하겠습니다!)

코드는 슬프게도 단 한줄 변경되었습니다... (+ 쿼리 클라이언트 제거....)

## 🔍 변경사항
<!-- 주요 변경사항을 bullet point로 작성해주세요 -->

회원탈퇴 시 로그아웃이 되지 않던 문제를 해결했습니다.

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 (ex. #123) -->

- close #110 

## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 작성해주세요 -->

인공지능은 잘 모르는 것 같긴하나 이 친구도 signOut을 적용하라고 하긴 합니다...(claude 3.5 sonnet) ~왜 edge랑 클라이언트 두 곳 다 있는지는...~
![image](https://github.com/user-attachments/assets/35400612-eb3f-4517-9b01-ae0c6038f82d)
![image](https://github.com/user-attachments/assets/7568c4e1-d470-4564-a421-2c80adafe8fb)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **버그 수정**
	- 사용자 계정 삭제 및 로그아웃 프로세스의 순서를 개선하여 세션 관리를 강화했습니다.
	- 로그아웃 후 성공 메시지를 표시하도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->