### PR TITLE
fix: 스위치 흔들리는 문제 해결

### DIFF
--- a/app/(protected)/setting.tsx
+++ b/app/(protected)/setting.tsx
@@ -183,32 +183,26 @@ function NotificationSetting({ setting }: { setting?: PushSetting | null }) {
 
   const granted = setting?.grantedNotifications || [];
   const allSwitch = useSharedValue(!!granted.length);
-  const isAllSwitchInit = useSharedValue(true);
   const SWITCH_CONFIG = {
     like: {
       title: "좋아요 알림",
       value: useSharedValue(granted.includes("like")),
-      isInit: useSharedValue(true),
     },
     comment: {
       title: "댓글 알림",
       value: useSharedValue(granted.includes("comment")),
-      isInit: useSharedValue(true),
     },
     mention: {
       title: "멘션 알림",
       value: useSharedValue(granted.includes("mention")),
-      isInit: useSharedValue(true),
     },
     poke: {
       title: "콕찌르기 알림",
       value: useSharedValue(granted.includes("poke")),
-      isInit: useSharedValue(true),
     },
     friend: {
       title: "친구요청 알림",
       value: useSharedValue(granted.includes("friend")),
-      isInit: useSharedValue(true),
     },
   } as const;
   type SwitchType = keyof typeof SWITCH_CONFIG;
@@ -244,14 +238,11 @@ function NotificationSetting({ setting }: { setting?: PushSetting | null }) {
     if (!(await checkPermission())) return;
 
     const prevAllSwitch = allSwitch.value;
-    for (const { value, isInit } of Object.values(SWITCH_CONFIG)) {
-      // 개별 스위치 업데이트
+    // 스위치 업데이트
+    for (const { value } of Object.values(SWITCH_CONFIG)) {
       value.value = !prevAllSwitch;
-      isInit.value = false;
     }
-    // 최상단 스위치 업데이트
     allSwitch.value = !prevAllSwitch;
-    isAllSwitchInit.value = false;
 
     // DB에 변경사항 반영
     const newGranted = prevAllSwitch
@@ -265,25 +256,17 @@ function NotificationSetting({ setting }: { setting?: PushSetting | null }) {
     if (!(await checkPermission())) return;
 
     const prevValue = SWITCH_CONFIG[type].value.value;
-
-    // 최상단 스위치 업데이트
+    // 스위치 업데이트
     if (!prevValue) {
-      // 하나라도 true면 allSwitch도 true
       allSwitch.value = true;
-      isAllSwitchInit.value = false;
     } else if (
       Object.entries(SWITCH_CONFIG).every(
         ([key, { value }]) => key === type || !value.value,
       )
     ) {
-      // 나 제외 나머지 것들도 다 false 이면 allSwitch도 false
       allSwitch.value = false;
-      isAllSwitchInit.value = false;
     }
-
-    // 개별 스위치 업데이트
     SWITCH_CONFIG[type].value.value = !SWITCH_CONFIG[type].value.value;
-    SWITCH_CONFIG[type].isInit.value = false;
 
     // DB에 변경사항 반영
     const typesToUpdate = NOTIFICATION_TYPE_GROUPS[type];
@@ -297,11 +280,7 @@ function NotificationSetting({ setting }: { setting?: PushSetting | null }) {
     <View className="gap-5 bg-white px-6 py-[22px]">
       <View className="flex-row items-center justify-between ">
         <Text className="heading-2 text-gray-80">알림 설정</Text>
-        <CustomSwitch
-          value={allSwitch}
-          isInit={isAllSwitchInit}
-          onPress={handleAllSwitchPress}
-        />
+        <CustomSwitch value={allSwitch} onPress={handleAllSwitchPress} />
       </View>
       {/* 개별 스위치 리스트 */}
       <View className="gap-5 pl-2">
@@ -312,7 +291,6 @@ function NotificationSetting({ setting }: { setting?: PushSetting | null }) {
             </Text>
             <CustomSwitch
               value={SWITCH_CONFIG[type as SwitchType].value}
-              isInit={SWITCH_CONFIG[type as SwitchType].isInit}
               onPress={() => handleSwitchPress(type as SwitchType)}
             />
           </View>

--- a/components/CustomSwitch.tsx
+++ b/components/CustomSwitch.tsx
@@ -10,7 +10,6 @@ import Animated, {
 
 interface SwitchProps {
   value: SharedValue<boolean>;
-  isInit: SharedValue<boolean>;
   onPress: () => void;
   duration?: number;
   size?: {
@@ -23,9 +22,8 @@ interface SwitchProps {
 
 export default function CustomSwitch({
   value,
-  isInit,
   onPress,
-  duration = 400,
+  duration = 250,
   size = { width: 45, height: 22, padding: 3 },
   trackColors = { on: colors.primary, off: colors.gray[25] },
 }: SwitchProps) {
@@ -37,9 +35,7 @@ export default function CustomSwitch({
       [0, 1],
       [trackColors.off, trackColors.on],
     );
-    const colorValue = withTiming(color, {
-      duration: isInit.value ? 0 : duration,
-    });
+    const colorValue = withTiming(color, { duration });
 
     return {
       backgroundColor: colorValue,
@@ -53,9 +49,7 @@ export default function CustomSwitch({
       [0, 1],
       [0, size.width - size.height],
     );
-    const translateValue = withTiming(moveValue, {
-      duration: isInit.value ? 0 : duration,
-    });
+    const translateValue = withTiming(moveValue, { duration });
 
     return {
       transform: [{ translateX: translateValue }],


### PR DESCRIPTION
## 📝 PR 설명
일부 폰에서 스위치 on/off 변경시 흔들리는 문제가 있었습니다.
duration을 줄이니 (당연히) 속도가 빨라졌지만, 스위치가 안 흔들리는 것 같아서 줄였습니다.

## 🔍 변경사항
- duration 줄임
- isInit 없어도 원하는대로 동작해서 삭제

## 🔗 관련 이슈
- close #106 

## 📌 기타 참고사항
리뷰시 확인해주면 좋을 것들
- 계정 설정 페이지 들어갔을 땐 애니메이션 없이 기존 설정값을 보여준다
- 계정 설정 페이지에서 알림 설정 스위치를 누르면 스위치가 부드럽게 on/off 된다 (특히 기존에 흔들렸던 분들)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 알림 설정 관리의 간소화 및 개선.
- **버그 수정**
	- 초기화 상태와 관련된 불필요한 변수 제거로 로직 간소화.
- **문서화**
	- 주석 업데이트로 변경된 로직 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->