### PR TITLE
feat: 친구 관련 페이지 무한스크롤 구현

### DIFF
--- a/app/(protected)/(tabs)/friend/_layout.tsx
+++ b/app/(protected)/(tabs)/friend/_layout.tsx
@@ -44,6 +44,7 @@ export default function FriendLayout() {
         options={{
           tabBarLabel: ({ focused }) => TabBarLabel("친구 요청", focused),
           tabBarAccessibilityLabel: "친구 요청 탭",
+          lazy: true,
         }}
       />
     </Tab.Navigator>

--- a/app/(protected)/(tabs)/friend/index.tsx
+++ b/app/(protected)/(tabs)/friend/index.tsx
@@ -5,43 +5,27 @@ import ErrorScreen from "@/components/ErrorScreen";
 import { FriendItem } from "@/components/FriendItem";
 import LoadingScreen from "@/components/LoadingScreen";
 import { SearchLayout } from "@/components/SearchLayout";
-import useFetchData from "@/hooks/useFetchData";
-import type { StatusInfo } from "@/types/Friend.interface";
-import type { UserProfile } from "@/types/User.interface";
+import useInfiniteLoad from "@/hooks/useInfiniteLoad";
 import { debounce } from "@/utils/DelayManager";
 import { formatDate } from "@/utils/formatDate";
-import { getFriends, getFriendsStatus, supabase } from "@/utils/supabase";
+import { getFriends, supabase } from "@/utils/supabase";
 import { useFocusEffect } from "expo-router";
+
+const LIMIT = 12;
 
 export default function Friend() {
   const queryClient = useQueryClient();
-  const [friends, setFriends] = useState<UserProfile[]>([]);
   const [keyword, setKeyword] = useState("");
 
   // 유저의 친구 정보 조회
   const {
-    data: friendsData,
-    isLoading: isFriendLoading,
-    error: friendError,
-  } = useFetchData<UserProfile[]>(
-    ["friends", keyword],
-    () => getFriends(keyword),
-    "친구 조회에 실패했습니다.",
-  );
-
-  const friendIds = friendsData?.map((friend) => friend.id);
-
-  // 친구의 운동 상태 정보 조회
-  const {
-    data: statusData,
-    isLoading: isStatusLoading,
-    error: statusError,
-  } = useFetchData<StatusInfo[]>(
-    ["friends", "status"],
-    () => getFriendsStatus(friendIds || []),
-    "친구 조회에 실패했습니다.",
-    !!friendIds?.length,
-  );
+    data: friendData,
+    isLoading,
+    isFetchingNextPage,
+    error,
+    loadMore,
+  } = useInfiniteLoad(getFriends(keyword), ["friends", keyword], LIMIT);
+  const friends = friendData?.pages.flatMap((page) => page.data) || [];
 
   const handleKeywordChange = debounce((newKeyword: string) => {
     setKeyword(newKeyword);
@@ -49,16 +33,16 @@ export default function Friend() {
 
   // 친구창에 focus 들어올 때마다 친구목록 새로고침 (검색중일 때 제외)
   useFocusEffect(() => {
-    if (!keyword) {
+    if (!keyword && !isFetchingNextPage) {
       queryClient.invalidateQueries({ queryKey: ["friends"] });
     }
   });
 
   // 친구의 운동 정보가 바뀌면 쿼리 다시 패치하도록 정보 구독
   useEffect(() => {
-    if (!friendIds?.length) return;
-
     const today = formatDate(new Date());
+    const friendIds = friends?.map(({ id }) => id);
+
     const statusChannel = supabase
       .channel("workoutHistory")
       .on(
@@ -73,7 +57,7 @@ export default function Friend() {
           // DELETE는 상세내용 감지가 안되어서 실시간 업데이트 X
           // 필요성도 INSERT에 비해 크지 않을 것으로 생각됨
           if (payload.new.date === today)
-            queryClient.invalidateQueries({ queryKey: ["friends", "status"] });
+            queryClient.invalidateQueries({ queryKey: ["friends"] });
         },
       )
       .subscribe();
@@ -81,51 +65,22 @@ export default function Friend() {
     return () => {
       supabase.removeChannel(statusChannel);
     };
-  }, [friendIds, queryClient.invalidateQueries]);
-
-  // 친구 목록이나 친구 운동 기록이 바뀔때마다 데이터 가공
-  useEffect(() => {
-    if (!friendsData) return;
-    if (!statusData?.length) {
-      setFriends(friendsData);
-      return;
-    }
-
-    const getStatus = (friendId: string) =>
-      statusData?.find(({ userId }) => friendId === userId)?.status;
-
-    setFriends(
-      friendsData
-        .map((friend) => {
-          const status = getStatus(friend.id);
-          return status ? { ...friend, status } : friend;
-        })
-        .sort((a, b) => {
-          if (a.status && !b.status) return 1;
-          if (!a.status && b.status) return -1;
-          return 0;
-        }),
-    );
-  }, [friendsData, statusData]);
+  }, [friends, queryClient.invalidateQueries]);
 
   // 에러 스크린
-  if (friendError || statusError) {
-    const errorMessage =
-      friendError?.message ||
-      statusError?.message ||
-      "친구 조회에 실패했습니다.";
+  if (error) {
     return (
       <SearchLayout
         data={[]}
         onChangeKeyword={handleKeywordChange}
         renderItem={() => <></>}
-        emptyComponent={<ErrorScreen errorMessage={errorMessage} />}
+        emptyComponent={<ErrorScreen errorMessage={error.message} />}
       />
     );
   }
 
   // 로딩 스크린
-  if (isFriendLoading || isStatusLoading || !friendsData) {
+  if (isLoading) {
     return (
       <SearchLayout
         data={[]}
@@ -140,6 +95,8 @@ export default function Friend() {
     <SearchLayout
       data={friends}
       onChangeKeyword={handleKeywordChange}
+      loadMore={loadMore}
+      isFetchingNextPage={isFetchingNextPage}
       renderItem={({ item: friend }) => <FriendItem friend={friend} />}
       emptyComponent={
         <ErrorScreen

--- a/app/(protected)/(tabs)/friend/index.tsx
+++ b/app/(protected)/(tabs)/friend/index.tsx
@@ -24,7 +24,11 @@ export default function Friend() {
     isFetchingNextPage,
     error,
     loadMore,
-  } = useInfiniteLoad(getFriends(keyword), ["friends", keyword], LIMIT);
+  } = useInfiniteLoad({
+    queryFn: getFriends(keyword),
+    queryKey: ["friends", keyword],
+    limit: LIMIT,
+  });
   const friends = friendData?.pages.flatMap((page) => page.data) || [];
 
   const handleKeywordChange = debounce((newKeyword: string) => {

--- a/app/(protected)/(tabs)/friend/request.tsx
+++ b/app/(protected)/(tabs)/friend/request.tsx
@@ -20,13 +20,13 @@ export default function Request() {
 
   // 유저의 친구 요청 정보 조회
   const {
-    data: requests,
+    data: requestData,
     isLoading,
     isFetchingNextPage,
     error,
     loadMore,
   } = useInfiniteLoad(getFriendRequests, ["friendRequests"], LIMIT);
-  const hasRequests = !!requests?.pages[0].total;
+  const hasRequests = !!requestData?.pages[0].total;
 
   // 친구 요청창에 focus 들어올 때마다 친구목록 새로고침
   useFocusEffect(() => {
@@ -89,7 +89,7 @@ export default function Request() {
     <SafeAreaView edges={[]} className="flex-1 bg-white">
       <FlatList
         className="w-full grow px-8"
-        data={hasRequests ? requests.pages.flatMap((page) => page.data) : []}
+        data={hasRequests ? requestData.pages.flatMap((page) => page.data) : []}
         keyExtractor={(request) => String(request.requestId)}
         renderItem={({ item: request }) => (
           <FriendRequest {...request} isLoading={isLoading} />

--- a/app/(protected)/(tabs)/friend/request.tsx
+++ b/app/(protected)/(tabs)/friend/request.tsx
@@ -25,7 +25,11 @@ export default function Request() {
     isFetchingNextPage,
     error,
     loadMore,
-  } = useInfiniteLoad(getFriendRequests, ["friendRequests"], LIMIT);
+  } = useInfiniteLoad({
+    queryFn: getFriendRequests,
+    queryKey: ["friendRequests"],
+    limit: LIMIT,
+  });
   const hasRequests = !!requestData?.pages[0].total;
 
   // 친구 요청창에 focus 들어올 때마다 친구목록 새로고침

--- a/app/(protected)/(tabs)/home.tsx
+++ b/app/(protected)/(tabs)/home.tsx
@@ -8,6 +8,7 @@ import Icons from "@/constants/icons";
 import { default as imgs } from "@/constants/images";
 import useFetchData from "@/hooks/useFetchData";
 import useInfiniteLoad from "@/hooks/useInfiniteLoad";
+import useRefresh from "@/hooks/useRefresh";
 import { deletePost, getPostLikes, getPosts } from "@/utils/supabase";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
@@ -30,7 +31,6 @@ const { height: deviceHeight } = Dimensions.get("window");
 
 export default function Home() {
   const [userId, setUserId] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
   const [isCommentsVisible, setIsCommentsVisible] = useState(false);
   const [selectedPostId, setSelectedPostId] = useState<number | null>(null);
   const [selectedAuthorId, setSelectedAuthorId] = useState<string | null>(null);
@@ -78,14 +78,7 @@ export default function Home() {
     limit: LIMIT,
   });
 
-  const onRefresh = useCallback(async () => {
-    setRefreshing(true);
-    try {
-      await refetch();
-    } finally {
-      setRefreshing(false);
-    }
-  }, [refetch]);
+  const { refreshing, onRefresh } = useRefresh({ refetch });
 
   const deletePostMutation = useMutation({
     mutationFn: async () => {

--- a/app/(protected)/(tabs)/home.tsx
+++ b/app/(protected)/(tabs)/home.tsx
@@ -72,11 +72,11 @@ export default function Home() {
   }, []);
 
   // post 조회
-  const { data, isFetchingNextPage, refetch, loadMore } = useInfiniteLoad(
-    getPosts,
-    ["posts"],
-    LIMIT,
-  );
+  const { data, isFetchingNextPage, refetch, loadMore } = useInfiniteLoad({
+    queryFn: getPosts,
+    queryKey: ["posts"],
+    limit: LIMIT,
+  });
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);

--- a/app/(protected)/user/search.tsx
+++ b/app/(protected)/user/search.tsx
@@ -19,11 +19,11 @@ export default function UserSearch() {
     isFetchingNextPage,
     error,
     loadMore,
-  } = useInfiniteLoad(
-    getNonFriends(keyword),
-    ["search", "users", keyword],
-    LIMIT,
-  );
+  } = useInfiniteLoad({
+    queryFn: getNonFriends(keyword),
+    queryKey: ["search", "users", keyword],
+    limit: LIMIT,
+  });
   const hasData = !!userData?.pages[0].total;
 
   const handleKeywordChange = debounce((newKeyword: string) => {

--- a/app/(protected)/user/search.tsx
+++ b/app/(protected)/user/search.tsx
@@ -24,7 +24,7 @@ export default function UserSearch() {
     queryKey: ["search", "users", keyword],
     limit: LIMIT,
   });
-  const hasData = !!userData?.pages[0].total;
+  const showData = !!userData?.pages[0].total && !!keyword;
 
   const handleKeywordChange = debounce((newKeyword: string) => {
     setKeyword(newKeyword);
@@ -58,7 +58,7 @@ export default function UserSearch() {
 
   return (
     <SearchLayout
-      data={hasData ? userData.pages.flatMap((page) => page.data) : []}
+      data={showData ? userData.pages.flatMap((page) => page.data) : []}
       onChangeKeyword={handleKeywordChange}
       loadMore={loadMore}
       isFetchingNextPage={isFetchingNextPage}

--- a/app/(protected)/user/search.tsx
+++ b/app/(protected)/user/search.tsx
@@ -12,7 +12,7 @@ const LIMIT = 12;
 export default function UserSearch() {
   const [keyword, setKeyword] = useState("");
 
-  // 유저의 친구 요청 정보 조회
+  // 친구가 아닌 유저들 검색 키워드로 정보 조회
   const {
     data: userData,
     isFetching,

--- a/app/(protected)/user/search.tsx
+++ b/app/(protected)/user/search.tsx
@@ -15,7 +15,7 @@ export default function UserSearch() {
   // 유저의 친구 요청 정보 조회
   const {
     data: userData,
-    isLoading,
+    isFetching,
     isFetchingNextPage,
     error,
     loadMore,
@@ -45,7 +45,7 @@ export default function UserSearch() {
   }
 
   // 로딩 스크린
-  if (isLoading) {
+  if (isFetching) {
     return (
       <SearchLayout
         data={[]}

--- a/components/Refresh.tsx
+++ b/components/Refresh.tsx
@@ -1,0 +1,28 @@
+import type {
+  InfiniteData,
+  QueryObserverResult,
+  RefetchOptions,
+} from "@tanstack/react-query";
+import { useState } from "react";
+import { RefreshControl } from "react-native";
+
+export default function Refresh<T>({
+  refetch,
+}: {
+  refetch: (
+    options?: RefetchOptions,
+  ) => Promise<QueryObserverResult<InfiniteData<T, unknown>, Error>>;
+}) {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await refetch();
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />;
+}

--- a/components/SearchLayout.tsx
+++ b/components/SearchLayout.tsx
@@ -1,19 +1,29 @@
+import colors from "@/constants/colors";
 import type { UserProfile } from "@/types/User.interface";
 import { useState } from "react";
-import { FlatList, type ListRenderItemInfo, View } from "react-native";
+import {
+  ActivityIndicator,
+  FlatList,
+  type ListRenderItemInfo,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import SearchBar from "./SearchBar";
 
 interface SearchLayoutProps {
   data: UserProfile[]; // 추후 검색 사용 범위 넓어지면 변경 가능
+  isFetchingNextPage?: boolean;
   onChangeKeyword: (newKeyword: string) => void;
+  loadMore?: () => void;
   renderItem: (itemInfo: ListRenderItemInfo<UserProfile>) => React.ReactElement;
   emptyComponent: React.ReactElement;
 }
 
 export function SearchLayout<T>({
   data,
+  isFetchingNextPage,
   onChangeKeyword,
+  loadMore,
   renderItem,
   emptyComponent,
 }: SearchLayoutProps) {
@@ -22,10 +32,11 @@ export function SearchLayout<T>({
   return (
     <SafeAreaView edges={[]} className="flex-1 bg-white">
       <FlatList
+        className="w-full grow px-6"
         data={data}
         keyExtractor={(elem) => elem.id}
         renderItem={renderItem}
-        className="w-full grow px-6"
+        onEndReached={loadMore}
         contentContainerStyle={data.length ? {} : { flex: 1 }}
         ListHeaderComponent={
           <SearchBar
@@ -38,7 +49,17 @@ export function SearchLayout<T>({
           />
         }
         ListEmptyComponent={emptyComponent}
-        ListFooterComponent={<View className="h-4" />}
+        ListFooterComponent={
+          isFetchingNextPage ? (
+            <ActivityIndicator
+              size="large"
+              className="py-4"
+              color={colors.primary}
+            />
+          ) : (
+            <View className="h-4" />
+          )
+        }
       />
     </SafeAreaView>
   );

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -85,7 +85,7 @@ export default function CommentItem({
 
   const diff = diffDate(new Date(createdAt));
 
-  // 유저의 친구 정보 조회
+  // 답글 가져오기
   const {
     data: replyData,
     isFetchingNextPage,

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -1,6 +1,7 @@
 import colors from "@/constants/colors";
 import Icons from "@/constants/icons";
 import images from "@/constants/images";
+import useInfiniteLoad from "@/hooks/useInfiniteLoad";
 import { useTruncateText } from "@/hooks/useTruncateText";
 import { diffDate } from "@/utils/formatDate";
 import {
@@ -8,12 +9,7 @@ import {
   getReplies,
   toggleLikeComment,
 } from "@/utils/supabase";
-import {
-  keepPreviousData,
-  useInfiniteQuery,
-  useMutation,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import { useCallback, useEffect, useState } from "react";
@@ -27,6 +23,8 @@ import {
 } from "react-native";
 import { FlatList } from "react-native";
 import CustomModal from "../Modal";
+
+const LIMIT = 5;
 
 interface CommentItemProps {
   id: number;
@@ -87,31 +85,17 @@ export default function CommentItem({
 
   const diff = diffDate(new Date(createdAt));
 
-  // 답글 가져오기
+  // 유저의 친구 정보 조회
   const {
     data: replyData,
-    fetchNextPage: replyFetchNextPage,
-    hasNextPage: replyHasNextPage,
-    isFetchingNextPage: isReplyFetchingNextPage,
-  } = useInfiniteQuery({
+    isFetchingNextPage,
+    hasNextPage,
+    loadMore,
+  } = useInfiniteLoad({
+    queryFn: getReplies(id),
     queryKey: ["replies", id],
-    queryFn: ({ pageParam = 0 }) =>
-      getReplies(id, pageParam, pageParam === 0 ? 1 : 5),
-    getNextPageParam: (lastPage) =>
-      lastPage.hasNext ? lastPage.nextPage : undefined,
-    enabled: !!totalReplies && totalReplies > 0,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-    placeholderData: keepPreviousData,
-    initialPageParam: 0,
+    genLimit: (pageParam: number) => (pageParam === 0 ? 1 : LIMIT),
   });
-
-  // 답글 더 불러오기
-  const loadMoreReply = useCallback(() => {
-    if (replyHasNextPage && !isReplyFetchingNextPage) {
-      replyFetchNextPage();
-    }
-  }, [replyHasNextPage, isReplyFetchingNextPage, replyFetchNextPage]);
 
   const handleOpenModal = useCallback(() => {
     setIsModalVisible(true);
@@ -327,7 +311,7 @@ export default function CommentItem({
           {!!replyData && (
             <FlatList
               className="gap-2"
-              data={replyData.pages.flatMap((page) => page.replies)}
+              data={replyData.pages.flatMap((page) => page.data)}
               keyExtractor={(item) => item.id.toString()}
               renderItem={({ item, index }) => (
                 <CommentItem
@@ -352,30 +336,30 @@ export default function CommentItem({
                 />
               )}
               ListFooterComponent={() =>
-                isReplyFetchingNextPage ? (
+                isFetchingNextPage ? (
                   <ActivityIndicator size="small" color={colors.primary} />
                 ) : null
               }
             />
           )}
 
-          {(totalReplies > 1 || replyHasNextPage) &&
+          {(totalReplies > 1 || hasNextPage) &&
             !!(
               totalReplies -
               (replyData?.pages.reduce(
-                (acc, page) => acc + page.replies.length,
+                (acc, page) => acc + page.data.length,
                 0,
               ) ?? 0)
             ) && (
               <TouchableOpacity
-                onPress={loadMoreReply}
+                onPress={loadMore}
                 className="w-full flex-1 items-center justify-center"
               >
                 <Text className="font-pregular text-[11px] text-gray-60">
                   + 답글{" "}
                   {totalReplies -
                     (replyData?.pages.reduce(
-                      (acc, page) => acc + page.replies.length,
+                      (acc, page) => acc + page.data.length,
                       0,
                     ) ?? 0)}
                   개 더보기

--- a/components/comments/CommentsSection.tsx
+++ b/components/comments/CommentsSection.tsx
@@ -3,6 +3,7 @@ import Icons from "@/constants/icons";
 import images from "@/constants/images";
 import useFetchData from "@/hooks/useFetchData";
 import useInfiniteLoad from "@/hooks/useInfiniteLoad";
+import useRefresh from "@/hooks/useRefresh";
 import {
   createComment,
   createNotification,
@@ -51,7 +52,6 @@ export default function CommentsSection({
   authorId,
 }: CommentsSectionProps) {
   const [userId, setUserId] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
   const [comment, setComment] = useState("");
   const [replyTo, setReplyTo] = useState<{
     userId: string;
@@ -95,14 +95,7 @@ export default function CommentsSection({
       limit: LIMIT,
     });
 
-  const onRefresh = useCallback(async () => {
-    setRefreshing(true);
-    try {
-      await refetch();
-    } finally {
-      setRefreshing(false);
-    }
-  }, [refetch]);
+  const { refreshing, onRefresh } = useRefresh({ refetch });
 
   // 답글달기 핸들러
   const handleReply = (

--- a/components/comments/CommentsSection.tsx
+++ b/components/comments/CommentsSection.tsx
@@ -2,6 +2,7 @@ import colors from "@/constants/colors";
 import Icons from "@/constants/icons";
 import images from "@/constants/images";
 import useFetchData from "@/hooks/useFetchData";
+import useInfiniteLoad from "@/hooks/useInfiniteLoad";
 import {
   createComment,
   createNotification,
@@ -10,12 +11,7 @@ import {
   getComments,
   getCurrentUser,
 } from "@/utils/supabase";
-import {
-  keepPreviousData,
-  useInfiniteQuery,
-  useMutation,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
 import * as SecureStore from "expo-secure-store";
@@ -38,6 +34,7 @@ import { showToast } from "../ToastConfig";
 import CommentItem from "./CommentItem";
 import MentionInput from "./MentionInput";
 
+const LIMIT = 5;
 const { height: deviceHeight, width: deviceWidth } = Dimensions.get("window");
 
 interface CommentsSectionProps {
@@ -91,28 +88,8 @@ export default function CommentsSection({
   );
 
   // 댓글 가져오기
-  const {
-    data,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    refetch,
-    isFetching,
-  } = useInfiniteQuery({
-    queryKey: ["comments", postId],
-    queryFn: ({ pageParam = 0 }) => getComments(postId, pageParam, 5),
-    getNextPageParam: (lastPage) =>
-      lastPage.hasNext ? lastPage.nextPage : undefined,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-    placeholderData: keepPreviousData,
-    initialPageParam: 0,
-  });
-
-  // 댓글 더 불러오기
-  const loadMore = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const { data, isFetching, isFetchingNextPage, refetch, loadMore } =
+    useInfiniteLoad(getComments(postId), ["comments", postId], LIMIT);
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -273,7 +250,7 @@ export default function CommentsSection({
             minIndexForVisible: 0,
           }}
           ListHeaderComponent={<View className="h-4" />}
-          data={data?.pages.flatMap((page) => page.comments) || []}
+          data={data?.pages.flatMap((page) => page.data) || []}
           keyExtractor={(item) => item.id.toString()}
           onEndReachedThreshold={0.5}
           onEndReached={() => {

--- a/components/comments/CommentsSection.tsx
+++ b/components/comments/CommentsSection.tsx
@@ -89,7 +89,11 @@ export default function CommentsSection({
 
   // 댓글 가져오기
   const { data, isFetching, isFetchingNextPage, refetch, loadMore } =
-    useInfiniteLoad(getComments(postId), ["comments", postId], LIMIT);
+    useInfiniteLoad({
+      queryFn: getComments(postId),
+      queryKey: ["comments", postId],
+      limit: LIMIT,
+    });
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);

--- a/hooks/useInfiniteLoad.tsx
+++ b/hooks/useInfiniteLoad.tsx
@@ -1,0 +1,44 @@
+import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
+
+export interface InfiniteResponse<T> {
+  data: T[];
+  total: number;
+  hasNext: boolean;
+  nextPage: number;
+}
+
+export default function useInfiniteLoad<T>(
+  queryFn: ({
+    page,
+    limit,
+  }: { page: number; limit: number }) => Promise<InfiniteResponse<T>>,
+  queryKey: string[],
+  limit: number,
+) {
+  const {
+    data,
+    error,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam = 0 }) => queryFn({ page: pageParam, limit: limit }),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.nextPage : undefined,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    placeholderData: keepPreviousData,
+    initialPageParam: 0,
+  });
+
+  const loadMore = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  return { data, error, isLoading, isFetchingNextPage, loadMore, refetch };
+}

--- a/hooks/useInfiniteLoad.tsx
+++ b/hooks/useInfiniteLoad.tsx
@@ -25,7 +25,7 @@ export default function useInfiniteLoad<T>(
     refetch,
   } = useInfiniteQuery({
     queryKey,
-    queryFn: ({ pageParam = 0 }) => queryFn({ page: pageParam, limit: limit }),
+    queryFn: ({ pageParam = 0 }) => queryFn({ page: pageParam, limit }),
     getNextPageParam: (lastPage) =>
       lastPage.hasNext ? lastPage.nextPage : undefined,
     refetchOnWindowFocus: false,

--- a/hooks/useInfiniteLoad.tsx
+++ b/hooks/useInfiniteLoad.tsx
@@ -7,15 +7,20 @@ export interface InfiniteResponse<T> {
   nextPage: number;
 }
 
-export default function useInfiniteLoad<T>(
+export default function useInfiniteLoad<T>({
+  queryFn,
+  queryKey,
+  limit,
+  genLimit,
+}: {
   queryFn: ({
     page,
     limit,
-  }: { page: number; limit: number }) => Promise<InfiniteResponse<T>>,
-  queryKey: (string | number)[],
-  limit: number,
-) {
-  console.log(limit);
+  }: { page?: number; limit?: number }) => Promise<InfiniteResponse<T>>;
+  queryKey: (string | number)[];
+  limit?: number;
+  genLimit?: (pageParams: number) => number;
+}) {
   const {
     data,
     error,
@@ -27,7 +32,8 @@ export default function useInfiniteLoad<T>(
     refetch,
   } = useInfiniteQuery({
     queryKey,
-    queryFn: ({ pageParam = 0 }) => queryFn({ page: pageParam, limit }),
+    queryFn: ({ pageParam = 0 }) =>
+      queryFn({ page: pageParam, limit: genLimit?.(pageParam) || limit }),
     getNextPageParam: (lastPage) =>
       lastPage.hasNext ? lastPage.nextPage : undefined,
     refetchOnWindowFocus: false,
@@ -48,6 +54,7 @@ export default function useInfiniteLoad<T>(
     isFetching,
     isLoading,
     isFetchingNextPage,
+    hasNextPage,
     loadMore,
     refetch,
   };

--- a/hooks/useInfiniteLoad.tsx
+++ b/hooks/useInfiniteLoad.tsx
@@ -12,12 +12,14 @@ export default function useInfiniteLoad<T>(
     page,
     limit,
   }: { page: number; limit: number }) => Promise<InfiniteResponse<T>>,
-  queryKey: string[],
+  queryKey: (string | number)[],
   limit: number,
 ) {
+  console.log(limit);
   const {
     data,
     error,
+    isFetching,
     isLoading,
     fetchNextPage,
     hasNextPage,
@@ -40,5 +42,13 @@ export default function useInfiniteLoad<T>(
     }
   };
 
-  return { data, error, isLoading, isFetchingNextPage, loadMore, refetch };
+  return {
+    data,
+    error,
+    isFetching,
+    isLoading,
+    isFetchingNextPage,
+    loadMore,
+    refetch,
+  };
 }

--- a/hooks/useManageFriend.ts
+++ b/hooks/useManageFriend.ts
@@ -108,7 +108,7 @@ const useManageFriend = () => {
       onError: (error) => {
         if (error instanceof NoRequestError) {
           // 친구 요청이 취소되어 발생한 에러라면 관련된 값 다시 불러오도록
-          queryClient.invalidateQueries({ queryKey: ["friendRequest"] });
+          queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
           queryClient.invalidateQueries({
             queryKey: ["relation", error.from],
           });

--- a/hooks/useRefresh.tsx
+++ b/hooks/useRefresh.tsx
@@ -4,9 +4,7 @@ import type {
   RefetchOptions,
 } from "@tanstack/react-query";
 import { useState } from "react";
-import { RefreshControl } from "react-native";
-
-export default function Refresh<T>({
+export default function useRefresh<T>({
   refetch,
 }: {
   refetch: (
@@ -24,5 +22,5 @@ export default function Refresh<T>({
     }
   };
 
-  return <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />;
+  return { refreshing, onRefresh };
 }

--- a/types/Friend.interface.ts
+++ b/types/Friend.interface.ts
@@ -14,12 +14,6 @@ export interface RequestInfo {
   fromUser: UserProfile;
 }
 
-export interface RequestResponse {
-  data: RequestInfo[];
-  total: number;
-  hasMore: boolean;
-}
-
 export interface FriendResponse {
   friends: UserProfile[];
   friendIds: string[];

--- a/types/Post.interface.ts
+++ b/types/Post.interface.ts
@@ -1,10 +1,28 @@
+interface UserData {
+  id: string;
+  username: string;
+  avatarUrl: string | null;
+}
+
+interface CommentData {
+  id: number;
+  contents: string;
+  createdAt: string;
+  userId: string;
+  author: UserData;
+}
+
 // 게시글 타입 정의
 export interface Post {
   id: number;
   images: string[];
-  contents: string | undefined;
+  contents: string | null;
   createdAt: string;
-  likes: number;
+  userData: UserData;
+  commentData: CommentData;
+  totalComments: number;
+  likedAvatars: string[];
+  isLikedByUser: boolean;
 }
 
 export interface Comment {

--- a/types/Post.interface.ts
+++ b/types/Post.interface.ts
@@ -25,7 +25,7 @@ export interface Post {
   isLikedByUser: boolean;
 }
 
-export interface Comment {
+interface CommentBase {
   id: number;
   contents: string;
   userId: string;
@@ -35,5 +35,13 @@ export interface Comment {
   isLiked: boolean;
   likedAvatars: string[];
   parentsCommentId: number;
+}
+
+export interface Comment extends CommentBase {
   totalReplies: number;
+}
+
+export interface Reply extends CommentBase {
+  replyCommentId: number;
+  replyTo: UserData;
 }

--- a/types/Post.interface.ts
+++ b/types/Post.interface.ts
@@ -26,11 +26,14 @@ export interface Post {
 }
 
 export interface Comment {
-  id: string;
-  content: string;
+  id: number;
+  contents: string;
   userId: string;
-  postId: number;
   createdAt: string;
-  liked: boolean;
-  likedAuthorAvatar: string[];
+  userData: UserData;
+  likes: number;
+  isLiked: boolean;
+  likedAvatars: string[];
+  parentsCommentId: number;
+  totalReplies: number;
 }

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,4 +1,5 @@
 import type { NotificationData } from "./Notification.interface";
+import type { StatusType } from "./User.interface";
 
 export type Json =
   | string
@@ -407,6 +408,21 @@ export type Database = {
           likedAvatars: string[];
           parentsCommentId: number;
           totalReplies: number;
+        }[];
+      };
+      get_friend_sort_by_status: {
+        Args: {
+          keyword: string;
+          start_idx: number;
+          num: number;
+        };
+        Returns: {
+          id: string;
+          username: string;
+          avatarUrl: string;
+          description: string | null;
+          status: StatusType;
+          totalCount: number;
         }[];
       };
       get_friend_status: {

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -20,6 +20,7 @@ import type {
   PushSetting,
 } from "@/types/Notification.interface";
 import type { Notification } from "@/types/Notification.interface";
+import type { Post } from "@/types/Post.interface";
 import type { User, UserProfile } from "@/types/User.interface";
 import type { Database } from "@/types/supabase";
 import { formMessage } from "./formMessage";
@@ -371,7 +372,10 @@ export async function uploadImage(file: ImagePicker.ImagePickerAsset) {
 // ============================================
 
 // 게시글 조회
-export const getPosts = async ({ page = 0, limit = 10 }) => {
+export const getPosts = async ({
+  page = 0,
+  limit = 10,
+}): Promise<InfiniteResponse<Post>> => {
   try {
     const { count, error: countError } = await supabase
       .from("post")
@@ -385,7 +389,7 @@ export const getPosts = async ({ page = 0, limit = 10 }) => {
     if (error) throw new Error("게시글을 가져오는데 실패했습니다.");
 
     return {
-      posts: data,
+      data,
       total: count ?? data.length,
       hasNext: count ? (page + 1) * limit < count : false,
       nextPage: page + 1,


### PR DESCRIPTION
## 📝 PR 설명
친구 관련 페이지에 무한 스크롤로 데이터를 받아오도록 구현했습니다.

## 🔍 변경사항
- 친구 페이지: rpc로 운동 상태까지 한번에 받아오도록 변경, 무한스크롤 적용
- 친구 요청 페이지/ 친구 찾기 페이지: 무한스크롤 적용

## 📌 기타 참고사항
친구 요청은 t2@t.com 11111111 계정에 많이 만들어 두었습니다.
친구 찾기는 친구 요청 관계가 없을수록 많이 나오는데, 아마 닉네임 검색으로 12명 만들기 어려울 것 같습니다..
친구 페이지는 친구를 많이 만들어보시면 테스트 할 수 있습니다...

민재님 무한스크롤 코드 베껴서 만들었는데, 훅으로 만들어서 민재님 코드에도 적용할 수 있습니다.
넣어드릴까요??


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 친구 요청 탭에 지연 로딩 기능 추가.
	- 친구 및 비친구 사용자 검색 기능 개선, 무한 스크롤 지원.
	- 댓글 및 답글 컴포넌트에서 무한 스크롤 기능 통합.
	- 사용자 및 댓글 데이터 구조 개선.
	- 새로운 훅 `useRefresh` 추가.

- **버그 수정**
	- 친구 요청 처리 시 오류 처리 로직 개선.

- **문서화**
	- 새로운 훅 `useRefresh` 추가 및 사용법 문서화.

- **스타일**
	- 로딩 상태 표시를 위한 `ActivityIndicator` 추가.

- **테스트**
	- 데이터 페칭 및 상태 관리 관련 테스트 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->