### PR TITLE
fix: 연속 콕찌르기 방지

### DIFF
--- a/hooks/useManageFriend.ts
+++ b/hooks/useManageFriend.ts
@@ -169,7 +169,7 @@ const useManageFriend = () => {
   };
 
   // 친구 콕 찌르기
-  const usePoke = () => {
+  const usePoke = ({ onError }: { onError?: () => void }) => {
     const { mutate } = useMutation<PokeProps, Error, PokeProps>({
       mutationFn: async ({ friend }) => {
         await createNotification({
@@ -191,6 +191,7 @@ const useManageFriend = () => {
       onError: (error) => {
         console.error("콕 찌르기 실패:", error);
         showToast("fail", "콕 찌르기에 실패했어요!");
+        onError?.();
       },
     });
 

--- a/hooks/useManageFriend.ts
+++ b/hooks/useManageFriend.ts
@@ -63,9 +63,7 @@ const useManageFriend = () => {
         queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
         queryClient.invalidateQueries({ queryKey: ["friends"] });
         queryClient.invalidateQueries({ queryKey: ["search", "users"] });
-        queryClient.invalidateQueries({
-          queryKey: ["relation", toUserId],
-        });
+        queryClient.invalidateQueries({ queryKey: ["relation", toUserId] });
       },
       onError: (error) => {
         console.error("친구 요청 생성 실패:", error);
@@ -101,17 +99,13 @@ const useManageFriend = () => {
       onSuccess: ({ fromUserId }) => {
         queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
         queryClient.invalidateQueries({ queryKey: ["friends"] });
-        queryClient.invalidateQueries({
-          queryKey: ["relation", fromUserId],
-        });
+        queryClient.invalidateQueries({ queryKey: ["relation", fromUserId] });
       },
       onError: (error) => {
         if (error instanceof NoRequestError) {
           // 친구 요청이 취소되어 발생한 에러라면 관련된 값 다시 불러오도록
           queryClient.invalidateQueries({ queryKey: ["friendRequest"] });
-          queryClient.invalidateQueries({
-            queryKey: ["relation", error.from],
-          });
+          queryClient.invalidateQueries({ queryKey: ["relation", error.from] });
         }
         console.error("친구 요청 수락 실패:", error);
         showToast("fail", "요청 수락에 실패했어요!");
@@ -130,9 +124,7 @@ const useManageFriend = () => {
       },
       onSuccess: ({ fromUserId }) => {
         queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
-        queryClient.invalidateQueries({
-          queryKey: ["relation", fromUserId],
-        });
+        queryClient.invalidateQueries({ queryKey: ["relation", fromUserId] });
       },
       onError: (error) => {
         console.error("친구 요청 거절 실패:", error);
@@ -156,9 +148,7 @@ const useManageFriend = () => {
       onSuccess: ({ toUserId }) => {
         queryClient.invalidateQueries({ queryKey: ["friends"] });
         queryClient.invalidateQueries({ queryKey: ["friendRequests"] });
-        queryClient.invalidateQueries({
-          queryKey: ["relation", toUserId],
-        });
+        queryClient.invalidateQueries({ queryKey: ["relation", toUserId] });
       },
       onError: (error) => {
         console.error("친구 끊기 실패:", error);
@@ -180,9 +170,7 @@ const useManageFriend = () => {
         return { friend };
       },
       onSuccess: ({ friend }) => {
-        queryClient.invalidateQueries({
-          queryKey: ["poke", friend.id],
-        });
+        queryClient.invalidateQueries({ queryKey: ["poke", friend.id] });
         showToast(
           "success",
           `👈 ${shorten_comment(friend.username, 10)}님을 콕! 찔렀어요`,

--- a/hooks/useTimer.ts
+++ b/hooks/useTimer.ts
@@ -34,6 +34,22 @@ export function useTimerWithStartAndDuration(onTimeout?: () => void) {
     return Math.max(0, Math.floor((expiration - now) / 1000));
   }, [expiration]);
 
+  // expiration만 설정
+  const start = useCallback((start: number, duration: number) => {
+    // expiration이 유효하지 않거나 현재보다 작으면 실행 X
+    const expiration = start + duration;
+    if (!expiration || expiration <= Date.now()) return;
+
+    setExpiration(expiration);
+  }, []);
+
+  // expiration 설정되면 timeLeft 계산해서 설정
+  useEffect(() => {
+    if (expiration > Date.now()) {
+      setTimeLeft(calculateTimeLeft());
+    }
+  }, [calculateTimeLeft, expiration]);
+
   useEffect(() => {
     let timer: NodeJS.Timeout;
 
@@ -47,18 +63,6 @@ export function useTimerWithStartAndDuration(onTimeout?: () => void) {
 
     return () => clearInterval(timer);
   }, [timeLeft, onTimeout, calculateTimeLeft]);
-
-  const start = useCallback(
-    (start: number, duration: number) => {
-      // expiration이 유효하지 않거나 현재보다 작으면 실행 X
-      const expiration = start + duration;
-      if (!expiration || expiration <= Date.now()) return;
-
-      setExpiration(expiration);
-      setTimeLeft(calculateTimeLeft());
-    },
-    [calculateTimeLeft],
-  );
 
   return { timeLeft, start };
 }

--- a/hooks/useTimer.ts
+++ b/hooks/useTimer.ts
@@ -48,14 +48,17 @@ export function useTimerWithStartAndDuration(onTimeout?: () => void) {
     return () => clearInterval(timer);
   }, [timeLeft, onTimeout, calculateTimeLeft]);
 
-  const start = (start: number, duration: number) => {
-    // expiration이 유효하지 않거나 현재보다 작으면 실행 X
-    const expiration = start + duration;
-    if (!expiration || expiration <= Date.now()) return;
+  const start = useCallback(
+    (start: number, duration: number) => {
+      // expiration이 유효하지 않거나 현재보다 작으면 실행 X
+      const expiration = start + duration;
+      if (!expiration || expiration <= Date.now()) return;
 
-    setExpiration(expiration);
-    setTimeLeft(calculateTimeLeft());
-  };
+      setExpiration(expiration);
+      setTimeLeft(calculateTimeLeft());
+    },
+    [calculateTimeLeft],
+  );
 
   return { timeLeft, start };
 }


### PR DESCRIPTION
## 📝 PR 설명
콕 찌르기 누르자마자 버튼 disabled해서 연속 콕 찌르기를 방지합니다.

## 🔍 변경사항
- isProcessing 추가: 콕 찌르기 & 타이머 설정하는 동안만 true

## 📌 기타 참고사항
- 연속 콕찌르기 되는지 확인 부탁드려요.
- poke 생성 전후, 새로운 찌르기정보 받기 isFetching, 타이머 설정 전후 등 나눠서 조건 넣어봤다가 중간에 짧은 abled 틈이 더 늘어서
일단 누르고부터 **실패 or 타이머 설정 후**까지 통합해서 isProcessing 하나로 했습니다.
- timer의 start 실행한 뒤 setIsProcessing(false)했는데, 타이머 설정이 반영되는 시점과 start 함수 종료되고 isProcessing 바뀌는 시점의 선후관계에 따라 아주 짧은 클릭가능한 시간(보라색)이 생기기도 합니다. 타이머 설정 후 짧은 텀을 주고 isProcessing 값을 변경하면 해결되긴 할텐데, 일단 의미상 그런 코드를 추가하진 않았습니다. 문제가 될 것 같으면 추가하도록 하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 친구 항목에서 포케 작업의 처리 상태를 관리하는 기능 추가.
	- 포케 작업 실패 시 사용자 정의 오류 처리 콜백을 지원하는 기능 추가.
	- 타이머 훅의 성능을 개선하기 위한 메모이제이션된 콜백 추가.

- **버그 수정**
	- 포케 작업 중 버튼 비활성화를 개선하여 사용자가 중복 클릭할 수 없도록 함.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->