### PR TITLE
refactor: subscribe 관련 코드 utils/supabase.ts로 이동

### DIFF
--- a/app/(protected)/user/[userId].tsx
+++ b/app/(protected)/user/[userId].tsx
@@ -9,11 +9,12 @@ import {
   getRelationship,
   getUser,
   getUserPosts,
+  subscribeFriendRequest,
   supabase,
 } from "@/utils/supabase";
+import type { RealtimeChannel } from "@supabase/supabase-js";
 import { useQueryClient } from "@tanstack/react-query";
 import { useLocalSearchParams } from "expo-router";
-import * as SecureStore from "expo-secure-store";
 import { useEffect, useState } from "react";
 import { Text, TouchableOpacity, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -67,7 +68,6 @@ function RequestButton({ userId, relation, onPress }: RequestButtonProps) {
 const User = () => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const { userId } = useLocalSearchParams();
-  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const queryClient = useQueryClient();
 
   const { data: user } = useFetchData(
@@ -88,45 +88,23 @@ const User = () => {
     "친구 정보를 불러올 수 없습니다.",
   );
 
-  // 유저 아이디 불러오기
-  useEffect(() => {
-    const handleLoadId = async () => {
-      try {
-        setCurrentUserId(await SecureStore.getItemAsync("userId"));
-      } catch (error) {
-        console.error("userId 조회 중 오류 발생:", error);
-        setCurrentUserId(null);
-      }
-    };
-
-    handleLoadId();
-  }, []);
-
   // 친구 요청이 추가되면 쿼리 다시 패치하도록 정보 구독
   useEffect(() => {
-    const requestChannel = supabase
-      .channel("friendRequest")
-      .on(
-        "postgres_changes",
-        {
-          event: "INSERT",
-          schema: "public",
-          table: "friendRequest",
-          filter: `to=eq.${currentUserId}`,
-        },
-        (payload) => {
-          if (payload.new.from === userId)
-            queryClient.invalidateQueries({
-              queryKey: ["relation", userId],
-            });
-        },
-      )
-      .subscribe();
+    let requestChannel: RealtimeChannel;
+
+    const handleSubscribe = async () => {
+      requestChannel = await subscribeFriendRequest((payload) => {
+        if (payload.new.from === userId)
+          queryClient.invalidateQueries({ queryKey: ["relation", userId] });
+      });
+    };
+
+    handleSubscribe();
 
     return () => {
       supabase.removeChannel(requestChannel);
     };
-  }, [currentUserId, userId, queryClient.invalidateQueries]);
+  }, [userId, queryClient.invalidateQueries]);
 
   return (
     <>


### PR DESCRIPTION
## 📝 PR 설명
일부 페이지에서 supabase 실시간 정보 구독하던 부분 utils/supabase.ts로 이동했습니다.

## 확인사항
- 친구 페이지에서 친구의 운동상태 바뀌었을 때 실시간 반영되는지 확인
- 친구 요청 페이지에서 새 요청 있을 때 실시간 반영되는지 확인
- 새 알림 올 때 아이콘에 배지 표시 되는지, 알림 페이지에서 새 알림 실시간 반영되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 친구 상태 및 요청에 대한 실시간 구독 기능 추가.
  - 알림 수신을 위한 새로운 구독 메커니즘 도입.
  
- **Bug Fixes**
  - 불필요한 상태 관리 로직 제거로 컴포넌트의 흐름 간소화.

- **Documentation**
  - 새로운 메서드 및 타입에 대한 설명 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->