### PR TITLE
fix: 프로필 사진 cover로 변경

### DIFF
--- a/app/(protected)/profile.tsx
+++ b/app/(protected)/profile.tsx
@@ -116,7 +116,7 @@ const Profile = () => {
                     : images.AvatarInput
                 }
                 className="size-[236px] rounded-full"
-                resizeMode="contain"
+                resizeMode="cover"
               />
               <Icons.CameraIcon
                 style={{ position: "absolute", bottom: 12, right: 14 }}

--- a/components/ProfileSection.tsx
+++ b/components/ProfileSection.tsx
@@ -25,6 +25,7 @@ export default function ProfileSection({
             className="size-[88px] rounded-full"
             accessibilityLabel="프로필 이미지"
             accessibilityRole="image"
+            resizeMode="cover"
           />
           <Text
             className="title-3 flex-1"


### PR DESCRIPTION
## 📝 PR 설명
<!-- PR에 대한 설명을 작성해주세요 -->

프로필 수정 프리뷰 이미지 cover, 실제 보여줄 이미지 또한 cover로 바꾸어주었습니다.
자를 때 N x N 정사각형이며 보여줄 때 또한 M x M 정사각형 cover이미지로 보여준다면 자르는 부분 원형으로 잘 들어갈 것 같습니다!

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 (ex. #123) -->

close #145 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일 변경**
	- 프로필 이미지의 표시 방식을 변경하여 더 나은 화면 커버리지 제공
	- 이미지 크기 조정 모드를 "cover"로 업데이트하여 이미지 품질 및 표현 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->