### PR TITLE
fix: 존재하는 게시물인데 삭제된 게시물이라고 표시되는 문제

### DIFF
--- a/app/(protected)/post/[postId].tsx
+++ b/app/(protected)/post/[postId].tsx
@@ -26,7 +26,11 @@ export default function PostDetail() {
 
   const router = useRouter();
 
-  const { data: post, error: postError } = useFetchData(
+  const {
+    data: post,
+    error: postError,
+    isLoading: isPostLoading,
+  } = useFetchData(
     ["post", postId],
     () => getPost(Number(postId)),
     "포스트를 불러오는데 실패했습니다.",
@@ -45,9 +49,9 @@ export default function PostDetail() {
   useFocusEffect(
     // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
     useCallback(() => {
-      if (!postError && post) return;
+      if (isPostLoading || (!postError && post)) return;
       openModal({ type: "POST_NOT_FOUND" });
-    }, [postError, post]),
+    }, [isPostLoading, postError, post]),
   );
 
   const onOpenLikedAuthor = useCallback(() => {


### PR DESCRIPTION
## 📝 PR 설명

마이 페이지에서 게시글 선택 후 게시글로 이동되면, 분명 존재하는 게시글임에도 "게시글이 삭제되었어요"라는 모달이 뜨는 문제를 수정했습니다.

<img src="https://github.com/user-attachments/assets/4b16d435-27a6-4b8f-989f-ee79b4b0329b" width="200" />

자세한 건 #151 이슈에서 확인하실 수 있습니다!

## 🔍 변경사항
- isLoading 사용하여 post가 불러와지고 나서 삭제되었는지 아닌지 판단하도록 수정

## 🔗 관련 이슈

close #151 

## 📌 기타 참고사항

main 브랜치에서는 마이페이지 게시글 눌렀을 때 모달 뜨고, 현재 브랜치에서는 안 뜨는 지 확인해주시면 감사하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 게시물 세부 정보 페이지의 데이터 로딩 상태 처리 개선
- **버그 수정**
	- 게시물 로딩 중 오류 처리 로직 최적화
	- 데이터 페치 중 모달 열림 방지 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->