### PR TITLE
feat: 해당하는 페이지에서 하단 탭 터치시 스크롤 최상단으로 이동

### DIFF
--- a/app/(protected)/(tabs)/_layout.tsx
+++ b/app/(protected)/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Tabs } from "expo-router";
-import { Platform, Text, View } from "react-native";
+import { DeviceEventEmitter, Platform, Text, View } from "react-native";
 
 import { HeaderWithBack, HeaderWithNotification } from "@/components/Header";
 import useSubscribeNotification from "@/hooks/useSubscribeNotification";
@@ -81,6 +81,14 @@ export default function TabsLayout() {
             title: "Home",
             tabBarIcon: ({ color }) => <TabIcon color={color} name="HOME" />,
           }}
+          listeners={({ navigation, route }) => ({
+            tabPress: (e) => {
+              const state = navigation.getState();
+              if (state.routes[state.index].name === route.name) {
+                DeviceEventEmitter.emit("SCROLL_HOME_TO_TOP");
+              }
+            },
+          })}
         />
         <Tabs.Screen
           name="friend"
@@ -89,6 +97,14 @@ export default function TabsLayout() {
             title: "Friend",
             tabBarIcon: ({ color }) => <TabIcon color={color} name="FRIEND" />,
           }}
+          listeners={({ navigation, route }) => ({
+            tabPress: (e) => {
+              const state = navigation.getState();
+              if (state.routes[state.index].name === route.name) {
+                DeviceEventEmitter.emit("SCROLL_FRIEND_TO_TOP");
+              }
+            },
+          })}
         />
         <Tabs.Screen
           name="upload"
@@ -119,6 +135,14 @@ export default function TabsLayout() {
             title: "MyPage",
             tabBarIcon: ({ color }) => <TabIcon color={color} name="MY_PAGE" />,
           }}
+          listeners={({ navigation, route }) => ({
+            tabPress: (e) => {
+              const state = navigation.getState();
+              if (state.routes[state.index].name === route.name) {
+                DeviceEventEmitter.emit("SCROLL_MY_PAGE_TO_TOP");
+              }
+            },
+          })}
         />
       </Tabs>
     </>

--- a/app/(protected)/(tabs)/friend/index.tsx
+++ b/app/(protected)/(tabs)/friend/index.tsx
@@ -23,6 +23,7 @@ export default function Friend() {
     isFetchingNextPage,
     error,
     loadMore,
+    refetch,
   } = useInfiniteLoad({
     queryFn: getFriends(keyword),
     queryKey: ["friends", keyword],
@@ -80,6 +81,7 @@ export default function Friend() {
 
   return (
     <SearchLayout
+      refetch={refetch}
       data={friends}
       onChangeKeyword={handleKeywordChange}
       loadMore={loadMore}

--- a/app/(protected)/(tabs)/home.tsx
+++ b/app/(protected)/(tabs)/home.tsx
@@ -8,6 +8,8 @@ import useFetchData from "@/hooks/useFetchData";
 import useInfiniteLoad from "@/hooks/useInfiniteLoad";
 import { useModal } from "@/hooks/useModal";
 import useRefresh from "@/hooks/useRefresh";
+import { useScrollToTop } from "@/hooks/useScrollToTop";
+import type { Post } from "@/types/Post.interface";
 import { getPostLikes, getPosts } from "@/utils/supabase";
 import { useRouter } from "expo-router";
 import * as SecureStore from "expo-secure-store";
@@ -91,9 +93,15 @@ export default function Home() {
     handleLoadId();
   }, []);
 
+  const flatListRef = useScrollToTop<Post>({
+    event: "SCROLL_HOME_TO_TOP",
+    onRefetch: refetch,
+  });
+
   return (
     <SafeAreaView edges={[]} className="flex-1 items-center justify-center">
       <FlatList
+        ref={flatListRef}
         data={data?.pages.flatMap((page) => page.data) ?? []}
         keyExtractor={(item) => item.id.toString()}
         contentContainerStyle={{ gap: 10 }}

--- a/app/(protected)/(tabs)/mypage.tsx
+++ b/app/(protected)/(tabs)/mypage.tsx
@@ -20,6 +20,7 @@ export default function MyPage() {
     data: posts,
     isLoading: isPostsLoading,
     isError: isPostsError,
+    refetch,
   } = useFetchData(
     ["userPosts"],
     () => getMyPosts(),
@@ -43,6 +44,7 @@ export default function MyPage() {
             }
           />
           <PostGrid
+            refetch={refetch}
             posts={
               posts
                 ? posts.map((post) => ({ ...post, id: post.id.toString() }))

--- a/components/PostGrid.tsx
+++ b/components/PostGrid.tsx
@@ -1,4 +1,5 @@
 import images from "@/constants/images";
+import { useScrollToTop } from "@/hooks/useScrollToTop";
 import { useRouter } from "expo-router";
 import {
   Dimensions,
@@ -14,11 +15,12 @@ interface Post {
 }
 
 interface PostGridProps {
+  refetch: () => void;
   posts: Post[] | null;
   isError?: boolean;
 }
 
-export default function PostGrid({ posts, isError }: PostGridProps) {
+export default function PostGrid({ refetch, posts, isError }: PostGridProps) {
   const router = useRouter();
 
   if (isError) {
@@ -49,9 +51,15 @@ export default function PostGrid({ posts, isError }: PostGridProps) {
     );
   }
 
+  const flatListRef = useScrollToTop<Post>({
+    event: "SCROLL_HOME_TO_TOP",
+    onRefetch: refetch,
+  });
+
   return (
     <View className="mt-[32px] h-full bg-gray-5">
       <FlatList
+        ref={flatListRef}
         data={posts}
         renderItem={({ item }) => {
           const size = Dimensions.get("window").width / 3;

--- a/components/SearchLayout.tsx
+++ b/components/SearchLayout.tsx
@@ -1,4 +1,5 @@
 import colors from "@/constants/colors";
+import { useScrollToTop } from "@/hooks/useScrollToTop";
 import type { UserProfile } from "@/types/User.interface";
 import { useState } from "react";
 import {
@@ -11,6 +12,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import SearchBar from "./SearchBar";
 
 interface SearchLayoutProps {
+  refetch?: () => void;
   data: UserProfile[]; // 추후 검색 사용 범위 넓어지면 변경 가능
   isFetchingNextPage?: boolean;
   onChangeKeyword: (newKeyword: string) => void;
@@ -20,6 +22,7 @@ interface SearchLayoutProps {
 }
 
 export function SearchLayout<T>({
+  refetch,
   data,
   isFetchingNextPage,
   onChangeKeyword,
@@ -28,10 +31,15 @@ export function SearchLayout<T>({
   emptyComponent,
 }: SearchLayoutProps) {
   const [keyword, setKeyword] = useState("");
+  const flatListRef = useScrollToTop<UserProfile>({
+    event: "SCROLL_FRIEND_TO_TOP",
+    onRefetch: refetch,
+  });
 
   return (
     <SafeAreaView edges={[]} className="flex-1 bg-white">
       <FlatList
+        ref={flatListRef}
         className="w-full grow px-6"
         data={data}
         keyExtractor={(elem) => elem.id}

--- a/hooks/useScrollToTop.ts
+++ b/hooks/useScrollToTop.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from "react";
+import { DeviceEventEmitter, type FlatList } from "react-native";
+
+type UseScrollToTopProps = {
+  event: string;
+  onRefetch?: () => void;
+};
+
+export const useScrollToTop = <T>({
+  event,
+  onRefetch,
+}: UseScrollToTopProps) => {
+  const flatListRef = useRef<FlatList<T>>(null);
+
+  useEffect(() => {
+    const subscription = DeviceEventEmitter.addListener(event, () => {
+      flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+      console.log(event);
+      onRefetch?.();
+    });
+
+    return () => subscription.remove();
+  }, [event, onRefetch]);
+
+  return flatListRef;
+};


### PR DESCRIPTION
## 📝 PR 설명
해당하는 페이지에서 하단 탭 터치하면 최상단으로 스크롤 되고 리패치 하도록 추가했습니다.

기록이랑 업로드는 필요 없을거 같아서 홈, 친구, 마이 페이지에만 추가했습니다.

친구는 친구 목록만 스크롤 되고 친구 요청에서는 동작안합니다.

제가 친구랑 글이 적어서 테스트를 못했는데 많은 계정 있으면 확인 부탁드립니다.

## 📸 스크린샷
![Screenshot 2025-01-03 at 14 34 14](https://github.com/user-attachments/assets/dfdf7316-5823-47ba-873a-405a7f3fd835)


## 🔗 관련 이슈
- close #153 
