### PR TITLE
feat: OAuth 이메일, 프로필 제한 및 다시 로그인 시 계정 선택 혹은 추가 가능하도록 변경

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -11,7 +11,7 @@ import {
 import { signIn, supabase } from "@/utils/supabase";
 import { validateSignInForm } from "@/utils/validation";
 import icons from "@constants/icons";
-import images from "@constants/images";
+import images, { DEFAULT_AVATAR_URL } from "@constants/images";
 import type { Provider } from "@supabase/supabase-js";
 import { makeRedirectUri } from "expo-auth-session";
 import * as QueryParams from "expo-auth-session/build/QueryParams";
@@ -58,6 +58,18 @@ const SignIn = () => {
       options: {
         redirectTo,
         skipBrowserRedirect: true,
+        // OAuth 스코프 설정 구글이면 이메일과 프로필, 깃허브면 이메일과 사용자 정보
+        scopes:
+          provider === "google" ? "email profile" : "read:user user:email",
+        queryParams:
+          provider === "google"
+            ? {
+                prompt: "select_account",
+                access_type: "offline",
+              }
+            : {
+                login: "true",
+              },
       },
     });
     if (error) throw error;
@@ -86,11 +98,7 @@ const SignIn = () => {
             username:
               session.user.user_metadata.full_name ||
               session.user.email.split("@")[0],
-            avatarUrl:
-              session.user.user_metadata.avatar_url ||
-              `https://ui-avatars.com/api/?name=${encodeURIComponent(
-                session.user.email,
-              )}`,
+            avatarUrl: DEFAULT_AVATAR_URL,
             isOAuth: true,
           });
 


### PR DESCRIPTION
## 📝 PR 설명
<!-- PR에 대한 설명을 작성해주세요 -->

OAuth 로그인 시 다른 계정 선택할 수 있도록 변경했고 이메일이랑 프로필만 받을 수 있도록 제한했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- Google 및 GitHub OAuth 로그인 기능 개선
	- 사용자 인증 프로세스의 범위 및 매개변수 최적화

- **개선 사항**
	- 기본 아바타 URL 추가로 사용자 프로필 이미지 처리 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->