### PR TITLE
fix: 최대글자로 자를 때 이모티콘 고려, 알림 개선

### DIFF
--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -33,11 +33,11 @@ export function NotificationItem({
           />
 
           <View className="gap-[4px] w-[198px]">
-            <Text className="title-4 text-gray-90" numberOfLines={1}>
+            <Text className="body-2 text-gray-90" numberOfLines={1}>
               {message.title}
             </Text>
             {type === "like" || type === "commentLike" ? (
-              <Text className="title-4 text-gray-90" numberOfLines={1}>
+              <Text className="body-2 text-gray-90" numberOfLines={1}>
                 {message.content}
               </Text>
             ) : (

--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -32,7 +32,7 @@ export function NotificationItem({
             style={{ width: 48, height: 48, borderRadius: 9999 }}
           />
 
-          <View className="gap-[4px] w-[198px]">
+          <View className="gap-[4px] w-[204px]">
             <Text className="body-2 text-gray-90" numberOfLines={1}>
               {message.title}
             </Text>

--- a/hooks/useManageFriend.ts
+++ b/hooks/useManageFriend.ts
@@ -1,7 +1,7 @@
 import { showToast } from "@/components/ToastConfig";
 import { NOTIFICATION_TYPE } from "@/types/Notification.interface";
 import type { UserProfile } from "@/types/User.interface";
-import { shorten_comment } from "@/utils/formMessage";
+import { shortenMessage } from "@/utils/formMessage";
 import {
   acceptFriendRequest,
   checkFriendRequest,
@@ -173,7 +173,7 @@ const useManageFriend = () => {
         queryClient.invalidateQueries({ queryKey: ["poke", friend.id] });
         showToast(
           "success",
-          `👈 ${shorten_comment(friend.username, 10)}님을 콕! 찔렀어요`,
+          `👈 ${shortenMessage(friend.username, 10)}님을 콕! 찔렀어요`,
         );
       },
       onError: (error) => {

--- a/utils/formMessage.ts
+++ b/utils/formMessage.ts
@@ -3,13 +3,11 @@ import {
   type NotificationType,
 } from "@/types/Notification.interface";
 
-const COMMENT_MAX_LENGTH = 18;
-
-export const shorten_comment = (
-  comment: string,
-  maxLength = COMMENT_MAX_LENGTH,
-) =>
-  `"${comment.length > maxLength ? comment.slice(0, maxLength).concat("...") : comment}"`;
+export const shortenMessage = (message: string, maxLength: number) => {
+  // 이모지는 두 바이트 이상일 수 있기 때문에 Array.from 사용해서 이모지 처리
+  const commentArray = Array.from(message);
+  return `${commentArray.length > maxLength ? commentArray.slice(0, maxLength).join("").concat("...") : message}`;
+};
 
 interface FormMessageProps {
   type: NotificationType;
@@ -31,11 +29,11 @@ export function formMessage({
     },
     [NOTIFICATION_TYPE.COMMENT]: {
       title: `${username}님의 댓글`,
-      content: shorten_comment(comment || ""),
+      content: `"${comment}"`,
     },
     [NOTIFICATION_TYPE.MENTION]: {
       title: `${username}님의 멘션`,
-      content: shorten_comment(comment || ""),
+      content: `"${comment}"`,
     },
     [NOTIFICATION_TYPE.COMMENT_LIKE]: {
       title: `${username}님이`,


### PR DESCRIPTION
## 📝 PR 설명
글자수 길이로 자를 때 이모티콘이 걸리는 경우 깨지는 문제 해결했습니다.
그리고 댓글/멘션 알림의 경우 글자수 기준으로 내용을 자르면 내용의 종류(이모티콘/한글/영문/공백)에 따라 길이가 들쭉날쭉해서, 너비를 지정하고 너비에 맞게 자동으로 자르도록 변경해 길이가 길어지면 오른쪽 따옴표가 짤리게 되었습니다.

## 🔍 변경사항
- shortenMessage 이름변경, 이모티콘 고려하도록 변경
- 댓글/멘션 양쪽에 따옴표 붙이되 길이 길어지면 오른쪽 따옴표 포함한 추가문자열 잘리도록 변경

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/9d551c47-04ae-4bdf-9cb5-5838898f9987" width="300" />
<img src="https://github.com/user-attachments/assets/62b13a87-2952-40b2-9b9a-b82d6f84a296" width="300" />

## 🔗 관련 이슈
- close #157

## 📌 기타 참고사항
- 준혁님 폰에서 길이가 짧아 좋아요 알림이 이상해 보였던 것 같은데, 길이 조절도 여기서 할까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 메시지 축약 기능이 `shortenMessage`로 업데이트되었습니다.
	- 이모지를 고려한 메시지 처리 방식 개선.

- **스타일**
	- 알림 항목의 메시지 텍스트 스타일 변경 (제목 및 내용의 클래스 이름 수정).
	- 알림 항목의 너비가 198px에서 204px로 증가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->