### PR TITLE
fix: 마이페이지 그리드 스크롤 하단 스크롤 오류 수정

### DIFF
--- a/components/PostGrid.tsx
+++ b/components/PostGrid.tsx
@@ -50,7 +50,7 @@ export default function PostGrid({ posts, isError }: PostGridProps) {
   }
 
   return (
-    <View className="mt-[32px] h-full bg-gray-5">
+    <View className="mt-[32px] flex-1 bg-gray-5">
       <FlatList
         data={posts}
         renderItem={({ item }) => {


### PR DESCRIPTION
## 📝 PR 설명
<!-- PR에 대한 설명을 작성해주세요 -->

마이페이지 여러 게시글이 있을 때 하단까지 내려가지 않던 문제를 수정하였습니다.

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 (ex. #123) -->

close #169 