### PR TITLE
fix: 탈퇴 후 모달이 안 닫히는 문제 해결

### DIFF
--- a/components/modals/TwoButtonModals.tsx
+++ b/components/modals/TwoButtonModals.tsx
@@ -160,6 +160,7 @@ export function AccountDeleteModal() {
     onSuccess: async () => {
       // 탈퇴 후 로그아웃
       await supabase.auth.signOut();
+      closeModal();
     },
     onError: () => {
       showToast("error", "탈퇴 도중 오류가 발생했습니다.");


### PR DESCRIPTION
## 📝 PR 설명
계정 탈퇴 후 모달이 안닫히는 문제가 있어서 수정했습니다

## 🔍 변경사항
`components/modals/TwoButtonModals.tsx`의 `AccountDeleteModal` 에 성공 시 `closeModal()` 추가

## 🔗 관련 이슈
close #170 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 개선**
    - 사용자 계정 삭제 후 모달이 자동으로 닫히도록 업데이트
    - 계정 삭제 작업 후 성공 시 모달 닫기 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->