### PR TITLE
refactor: 이미지 비율을 자유롭게 설정할 수 있도록 수정

### DIFF
--- a/app/(protected)/(tabs)/upload.tsx
+++ b/app/(protected)/(tabs)/upload.tsx
@@ -226,15 +226,11 @@ export default function Upload() {
                 onLongPress={drag}
                 delayLongPress={200}
                 activeOpacity={0.7}
-                className="relative"
+                className="relative size-[152px]"
                 disabled={uploadPostMutation.isPending}
               >
-                <Image
-                  source={{ uri: item.uri }}
-                  className="size-[152px] rounded-[10px]"
-                />
                 <TouchableOpacity
-                  className="-top-3 -right-3 absolute size-8 items-center justify-center rounded-full border-2 border-white bg-gray-25"
+                  className="-top-3 -right-3 absolute z-20 size-8 items-center justify-center rounded-full border-2 border-white bg-gray-25"
                   onPress={() =>
                     setImageItems((prev) =>
                       prev.filter((_, idx) => idx !== getIndex()),
@@ -244,10 +240,28 @@ export default function Upload() {
                 >
                   <Icons.XIcon width={16} height={16} color={colors.white} />
                 </TouchableOpacity>
+
+                <View className="relative flex-1 overflow-hidden rounded-[10px]">
+                  <Image
+                    accessibilityRole="image"
+                    source={{ uri: item.uri }}
+                    className="absolute inset-0 size-full"
+                    blurRadius={10}
+                  />
+                  <View className="absolute inset-0 bg-black/80" />
+                  <Image
+                    accessibilityRole="image"
+                    source={{ uri: item.uri }}
+                    className="size-full"
+                    style={{
+                      resizeMode: "contain",
+                    }}
+                  />
+                </View>
               </TouchableOpacity>
             </ScaleDecorator>
           )}
-          className="flex-shrink-0 flex-grow-0 pt-6"
+          className="flex-shrink-0 flex-grow-0 pt-6 pb-7"
           contentContainerStyle={{ gap: 16 }}
           containerStyle={{ paddingHorizontal: 16 }}
           autoscrollSpeed={70}
@@ -278,7 +292,7 @@ export default function Upload() {
         />
 
         {/* 글 입력란 */}
-        <View className="w-full items-center justify-center px-6 pt-7">
+        <View className="w-full items-center justify-center px-6">
           <TextInput
             className="body-1 h-[120px] w-full rounded-[10px] border border-gray-20 p-4"
             placeholder="자유롭게 글을 적어주세요. (선택)"

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -77,14 +77,23 @@ export default function Carousel({
             key={`carousel-item-${index}-${item}`}
           >
             <View style={{ width: screenWidth, height: imageHeight }}>
-              <Image
-                source={{ uri: item }}
-                className="size-full"
-                resizeMode="cover"
-                onError={(e) =>
-                  console.error("Image loading error:", e.nativeEvent.error)
-                }
-              />
+              <View className="relative flex-1 overflow-hidden">
+                <Image
+                  accessibilityRole="image"
+                  source={{ uri: item }}
+                  className="absolute inset-0 size-full"
+                  blurRadius={10}
+                />
+                <View className="absolute inset-0 bg-black/80" />
+                <Image
+                  accessibilityRole="image"
+                  source={{ uri: item }}
+                  className="size-full"
+                  style={{
+                    resizeMode: "contain",
+                  }}
+                />
+              </View>
 
               {/* heart animation */}
               <Animated.View

--- a/components/modals/ListModals.tsx
+++ b/components/modals/ListModals.tsx
@@ -255,8 +255,7 @@ export const IMAGE_LIMIT = 5;
 export const IMAGE_OPTIONS: ImagePickerOptions = {
   mediaTypes: ["images"],
   allowsEditing: true,
-  aspect: [1, 1],
-  quality: 0.5,
+  quality: 1,
   exif: false,
   legacy: Platform.OS === "android",
 };
@@ -294,8 +293,18 @@ export function SelectPostUploadImageModal({
             ...result.assets[0],
             uri: optimizedUri,
             mimeType: "image/webp",
-            width: 520,
-            height: 520,
+            width: (() => {
+              const { width, height } = result.assets[0];
+              if (width <= 720 && height <= 720) return width;
+              if (width > height) return 720;
+              return Math.floor((width / height) * 720);
+            })(),
+            height: (() => {
+              const { width, height } = result.assets[0];
+              if (width <= 720 && height <= 720) return height;
+              if (width > height) return Math.floor((height / width) * 720);
+              return 720;
+            })(),
           },
         };
 

--- a/utils/optimizeImage.ts
+++ b/utils/optimizeImage.ts
@@ -1,29 +1,14 @@
 import * as ImageManipulator from "expo-image-manipulator";
 
-/**
- * Optimize an image by resizing to a maximum dimension of 720 and converting to WebP format
- * @param uri string - The URI of the image
- * @param maxDimension number - Maximum width or height for resizing
- * @param quality number - Quality (0-1) for WebP compression
- * @returns Promise<string> - Optimized image URI
- */
 const optimizeImage = async (
   uri: string,
   maxDimension = 520,
 ): Promise<string> => {
   try {
-    const manipulatedImage = await ImageManipulator.manipulateAsync(
-      uri,
-      [
-        {
-          resize: { width: maxDimension, height: maxDimension },
-        },
-      ],
-      {
-        compress: 0.8,
-        format: ImageManipulator.SaveFormat.WEBP,
-      },
-    );
+    const manipulatedImage = await ImageManipulator.manipulateAsync(uri, [], {
+      compress: 0.6,
+      format: ImageManipulator.SaveFormat.WEBP,
+    });
     return manipulatedImage.uri;
   } catch (error) {
     console.error("Error optimizing image:", error);


### PR DESCRIPTION
## 📝 PR 설명
이미지를 자유형으로 편집이 가능 하도록 수정하고 메인에서 확인 시 배경에 불투명한 이미지가 보이도록 수정하였습니다

## 🔍 변경사항
- 이미지 업로드 시 자유형 편집으로 변경
- 이미지를 전부 보여줄 수 있도록 수정
- 빈 공간에 불투명한 이미지가 보여지도록 수정

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/754ae8e6-55d2-4444-8ece-7635bc210950)
![image](https://github.com/user-attachments/assets/5b74c30f-86eb-4b7b-a5b2-a6568e0dd53f)
![image](https://github.com/user-attachments/assets/8ed5dfb0-f724-4be6-8d1c-24de1b457ca4)


## 🔗 관련 이슈
- close #176 

## 📌 기타 참고사항
