### PR TITLE
refactor: 메인 네비게이션 터치 애니메이션 제거

### DIFF
--- a/app/(protected)/(tabs)/_layout.tsx
+++ b/app/(protected)/(tabs)/_layout.tsx
@@ -1,5 +1,11 @@
 import { Tabs } from "expo-router";
-import { DeviceEventEmitter, Platform, Text, View } from "react-native";
+import {
+  DeviceEventEmitter,
+  Platform,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 
 import { HeaderWithBack, HeaderWithNotification } from "@/components/Header";
 import useSubscribeNotification from "@/hooks/useSubscribeNotification";
@@ -25,7 +31,7 @@ const TAP_ICONS = {
 type TapType = keyof typeof TAP_ICONS;
 
 const TAP_NAME = {
-  HOME: "홈",
+  HOME: "Home",
   FRIEND: "친구",
   HISTORY: "기록",
   MY_PAGE: "마이",
@@ -40,9 +46,18 @@ const TabIcon = ({
   color: string;
   name: TapType;
 }) => (
-  <View className="w-fit items-center justify-center gap-0">
+  <View className="w-full items-center justify-center gap-0">
     {TAP_ICONS[name](color)}
-    <Text className="caption-1" style={{ color }}>
+    <Text
+      className="caption-1"
+      numberOfLines={1}
+      style={{
+        color,
+        minWidth: 50,
+        minHeight: 20,
+        textAlign: "center",
+      }}
+    >
       {TAP_NAME[name]}
     </Text>
   </View>
@@ -55,6 +70,17 @@ export default function TabsLayout() {
     <>
       <Tabs
         screenOptions={{
+          tabBarButton: (props) => {
+            return (
+              <TouchableOpacity
+                onPress={props.onPress}
+                activeOpacity={1}
+                className={`h-[80px] items-center justify-center pt-[4px] ${Platform.OS === "android" ? "pb-[10px]" : ""}`}
+              >
+                {props.children}
+              </TouchableOpacity>
+            );
+          },
           tabBarShowLabel: false,
           tabBarActiveTintColor: colors.gray[90],
           tabBarInactiveTintColor: colors.gray[55],
@@ -66,11 +92,9 @@ export default function TabsLayout() {
             height: 80,
             flexDirection: "row",
             ...(Platform.OS === "android" && {
-              paddingBottom: 24,
               justifyContent: "center",
               alignItems: "center",
             }),
-            ...(Platform.OS === "ios" && { paddingTop: 8 }),
           },
         }}
       >
@@ -131,11 +155,10 @@ export default function TabsLayout() {
             title: "Upload",
             tabBarStyle: { display: "none" },
             tabBarIcon: () => (
-              <View className="size-12 items-center justify-center rounded-full bg-primary p-3">
+              <View className="size-[48px] items-center justify-center rounded-full bg-primary p-[12px] ">
                 <icons.PlusIcon width={24} height={24} color={colors.white} />
               </View>
             ),
-            href: "/upload",
           }}
         />
         <Tabs.Screen

--- a/app/(protected)/(tabs)/_layout.tsx
+++ b/app/(protected)/(tabs)/_layout.tsx
@@ -75,7 +75,7 @@ export default function TabsLayout() {
               <TouchableOpacity
                 onPress={props.onPress}
                 activeOpacity={1}
-                className={`h-[80px] items-center justify-center pt-[4px] ${Platform.OS === "android" ? "pb-[10px]" : ""}`}
+                className={`h-[80px] items-center justify-center pt-[4px] ${Platform.OS === "android" ? "pb-[10px]" : "pb-[20px]"}`}
               >
                 {props.children}
               </TouchableOpacity>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/material-top-tabs": "^7.0.18",
     "@rneui/themed": "^4.0.0-rc.8",
+    "@sentry/react-native": "~6.3.0",
     "@supabase/supabase-js": "^2.46.2",
     "@tanstack/react-query": "^5.62.0",
     "base64-arraybuffer": "^1.0.2",
@@ -29,6 +30,7 @@
     "expo-linking": "~7.0.3",
     "expo-notifications": "~0.29.11",
     "expo-router": "~4.0.9",
+    "expo-secure-store": "~14.0.0",
     "expo-splash-screen": "^0.29.13",
     "expo-status-bar": "~2.0.0",
     "expo-updates": "~0.26.10",
@@ -48,9 +50,7 @@
     "react-native-svg": "15.8.0",
     "react-native-toast-message": "^2.2.1",
     "react-native-web": "~0.19.13",
-    "tailwindcss": "^3.4.15",
-    "expo-secure-store": "~14.0.0",
-    "@sentry/react-native": "~6.3.0"
+    "tailwindcss": "^3.4.15"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## 📝 PR 설명
하단 탭바를 터치하면 안드로이드에서 기본효과가 적용되어서 나오는데 해당 효과를 제거했습니다.

## 🔍 변경사항
- 안드로이드 하단 탭바 효과 제거

## 📸 스크린샷
![Screenshot 2025-02-24 at 23 35 40](https://github.com/user-attachments/assets/97224ff4-92de-416e-966b-bc091c369dc9)

## 🔗 관련 이슈
- close #175

## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 탭 인터페이스가 개선되어 홈 탭의 레이블이 '홈'에서 'Home'으로 변경되었습니다.
  - 탭 버튼 및 아이콘 영역의 터치 반응성과 스타일이 향상되어 보다 직관적인 사용자 경험을 제공합니다.

- **Chores**
  - 애플리케이션 안정성과 보안을 위해 라이브러리 의존성이 정리 및 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->