### PR TITLE
refactor: 게시글/댓글 좋아요 알림을 계속 보내지 않도록 수정

### DIFF
--- a/hooks/useManageFriend.ts
+++ b/hooks/useManageFriend.ts
@@ -79,7 +79,7 @@ const useManageFriend = () => {
       mutationFn: async ({ requestId, fromUserId }) => {
         // 친구 요청이 그사이 취소되었는지 확인
         const hasFriendRequest = requestId
-          ? await checkFriendRequest(String(requestId))
+          ? await checkFriendRequest(requestId)
           : await checkFriendRequestWithUserId(fromUserId);
         if (!hasFriendRequest) {
           throw new NoRequestError(

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1059,7 +1059,7 @@ export async function getFriendRequests({
 }
 
 // 친구요청 있는지 조회
-export async function checkFriendRequest(requestId: string): Promise<boolean> {
+export async function checkFriendRequest(requestId: number): Promise<boolean> {
   const { data, error } = await supabase
     .from("friendRequest")
     .select("id")
@@ -1409,6 +1409,54 @@ export async function getLatestStabForFriend(
 // 알림 생성
 export async function createNotification(notification: Notification) {
   const user = await getCurrentUser();
+
+  // 좋아요/댓글좋아요 타입인 경우에만 1시간 제한 체크
+  // 최근 1시간 이내 동일한 유저에게 보낸 알림이 있는지 확인
+  const oneHourAgo = new Date();
+  oneHourAgo.setHours(oneHourAgo.getHours() - 1);
+
+  // 쿼리 조건 설정
+  const query = supabase
+    .from("notification")
+    .select("createdAt, data")
+    .eq("from", user.id)
+    .eq("to", notification.to)
+    .eq("type", notification.type)
+    .gte("createdAt", oneHourAgo.toISOString());
+
+  // like 타입이면 postId로 필터링, commentLike 타입이면 commentInfo.id로 필터링
+  if (notification.type === "like" && notification.data?.postId) {
+    const { data: recentLikes, error } = await query
+      .contains("data", { postId: notification.data.postId })
+      .limit(1);
+
+    if (error) {
+      if (error.code !== "PGRST116") {
+        throw error;
+      }
+    } else if (recentLikes && recentLikes.length > 0) {
+      // 같은 게시물에 이미 좋아요 알림을 보냈다면 추가 알림 중단
+      return;
+    }
+  } else if (
+    notification.type === "commentLike" &&
+    notification.data?.commentInfo?.id
+  ) {
+    const { data: recentCommentLikes, error } = await query
+      .contains("data", {
+        commentInfo: { id: notification.data.commentInfo.id },
+      })
+      .limit(1);
+
+    if (error) {
+      if (error.code !== "PGRST116") {
+        throw error;
+      }
+    } else if (recentCommentLikes && recentCommentLikes.length > 0) {
+      // 같은 댓글에 이미 좋아요 알림을 보냈다면 추가 알림 중단
+      return;
+    }
+  }
 
   const { error } = await supabase
     .from("notification")


### PR DESCRIPTION
## 📝 PR 설명
기존에 게시글/댓글에 좋아요를 누르면 무한으로 알림이 전송이 되는 문제가 있는데 해당 문제를 수정했습니다

게시글/댓글에 좋아요를 누르면 한시간 이내에는 다시 알림이 안가도록 수정해놨습니다

## 🔍 변경사항
- 게시글/댓글 좋아요 시 알림이 게속 전송되는 문제 수정

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 (ex. #123) -->

## 📌 기타 참고사항
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 친구 요청 처리 로직을 개선하여 요청 승인 과정이 더욱 안정적으로 동작합니다.
- **New Features**
	- 알림 시스템이 강화되어 동일 유형의 알림이 한 시간 내에 중복 발송되지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->