### PR TITLE
refactor: 알림 • 계정 설정 페이지, 하단 탭바 디자인 수정

### DIFF
--- a/app/(protected)/(tabs)/_layout.tsx
+++ b/app/(protected)/(tabs)/_layout.tsx
@@ -87,8 +87,6 @@ export default function TabsLayout() {
           tabBarHideOnKeyboard: true,
           tabBarStyle: {
             backgroundColor: colors.white,
-            borderTopWidth: 1,
-            borderTopColor: colors.gray[20],
             height: 80,
             flexDirection: "row",
             ...(Platform.OS === "android" && {

--- a/app/(protected)/notification.tsx
+++ b/app/(protected)/notification.tsx
@@ -56,7 +56,7 @@ export default function Notification() {
         renderItem={({ item: notification }) => (
           <NotificationItem {...notification} />
         )}
-        className="w-full grow px-8"
+        className="w-full grow px-7"
         contentContainerStyle={notifications.length ? {} : { flex: 1 }}
         ListHeaderComponent={<View className="h-2" />}
         ListFooterComponent={<View className="h-[34px]" />}

--- a/app/(protected)/setting.tsx
+++ b/app/(protected)/setting.tsx
@@ -58,7 +58,7 @@ export default function Setting() {
 
   return (
     <SafeAreaView edges={[]} className="flex-1 bg-white">
-      <View className="gap-2 bg-gray-5 pb-2">
+      <View className="gap-2 bg-gray-10 pb-2">
         {/* 알림 설정 */}
         {isTokenPending ? (
           <View className="h-[324px] items-center justify-center">
@@ -70,14 +70,14 @@ export default function Setting() {
 
         {/* 계정 설정 */}
         <View className="bg-white px-6 py-[22px]">
-          <Text className="heading-2 text-gray-80">계정 설정</Text>
+          <Text className="title-1 text-gray-80">계정 설정</Text>
           <View className="mt-5 gap-5 px-2">
             {!currentUser?.isOAuth && (
               <TouchableOpacity
                 className="flex-row items-center justify-between"
                 onPress={() => router.push("/change-password")}
               >
-                <Text className="font-pmedium text-gray-80 text-xl">
+                <Text className="font-pregular text-gray-90 text-[18px]">
                   비밀번호 변경
                 </Text>
                 <Icons.ChevronRightIcon color={colors.gray[70]} />
@@ -87,7 +87,7 @@ export default function Setting() {
               className="flex-row items-center justify-between"
               onPress={() => openModal({ type: "SIGN_OUT" })}
             >
-              <Text className="font-pmedium text-gray-80 text-xl">
+              <Text className="font-pregular text-gray-90 text-[18px]">
                 로그아웃
               </Text>
               <Icons.ChevronRightIcon color={colors.gray[70]} />
@@ -96,7 +96,7 @@ export default function Setting() {
               className="flex-row items-center justify-between"
               onPress={() => openModal({ type: "ACCOUNT_DELETE" })}
             >
-              <Text className="font-pmedium text-gray-80 text-xl">
+              <Text className="font-pregular text-gray-90 text-[18px]">
                 계정 탈퇴
               </Text>
               <Icons.ChevronRightIcon color={colors.gray[70]} />
@@ -113,7 +113,7 @@ export default function Setting() {
               )
             }
           >
-            <Text className="heading-2 text-gray-80">문의하기</Text>
+            <Text className="title-1 text-gray-80">문의하기</Text>
           </TouchableOpacity>
         </View>
 
@@ -124,7 +124,7 @@ export default function Setting() {
               Linking.openURL("https://github.com/Epilogue-1/kokkok")
             }
           >
-            <Text className="heading-2 text-gray-80">
+            <Text className="title-1 text-gray-80">
               우리 앱 깃허브 놀러가기
             </Text>
           </TouchableOpacity>
@@ -253,14 +253,14 @@ function NotificationSetting({ setting }: { setting?: PushSetting | null }) {
   return (
     <View className="gap-5 bg-white px-6 py-[22px]">
       <View className="flex-row items-center justify-between ">
-        <Text className="heading-2 text-gray-80">알림 설정</Text>
+        <Text className="title-1 text-gray-80">알림 설정</Text>
         <CustomSwitch value={allSwitch} onPress={handleAllSwitchPress} />
       </View>
       {/* 개별 스위치 리스트 */}
       <View className="gap-5 pl-2">
         {Object.keys(SWITCH_CONFIG).map((type) => (
           <View key={type} className="flex-row items-center justify-between">
-            <Text className="font-pmedium text-gray-80 text-xl">
+            <Text className="font-pregular text-gray-80 text-[18px]">
               {SWITCH_CONFIG[type as SwitchType].title}
             </Text>
             <CustomSwitch

--- a/app/(protected)/setting.tsx
+++ b/app/(protected)/setting.tsx
@@ -70,16 +70,14 @@ export default function Setting() {
 
         {/* 계정 설정 */}
         <View className="bg-white px-6 py-[22px]">
-          <Text className="title-1 text-gray-80">계정 설정</Text>
+          <Text className="title-2 text-gray-80">계정 설정</Text>
           <View className="mt-5 gap-5 px-2">
             {!currentUser?.isOAuth && (
               <TouchableOpacity
                 className="flex-row items-center justify-between"
                 onPress={() => router.push("/change-password")}
               >
-                <Text className="font-pregular text-gray-90 text-[18px]">
-                  비밀번호 변경
-                </Text>
+                <Text className=" text-gray-90 body-1">비밀번호 변경</Text>
                 <Icons.ChevronRightIcon color={colors.gray[70]} />
               </TouchableOpacity>
             )}
@@ -87,18 +85,14 @@ export default function Setting() {
               className="flex-row items-center justify-between"
               onPress={() => openModal({ type: "SIGN_OUT" })}
             >
-              <Text className="font-pregular text-gray-90 text-[18px]">
-                로그아웃
-              </Text>
+              <Text className=" text-gray-90 body-1">로그아웃</Text>
               <Icons.ChevronRightIcon color={colors.gray[70]} />
             </TouchableOpacity>
             <TouchableOpacity
               className="flex-row items-center justify-between"
               onPress={() => openModal({ type: "ACCOUNT_DELETE" })}
             >
-              <Text className="font-pregular text-gray-90 text-[18px]">
-                계정 탈퇴
-              </Text>
+              <Text className=" text-gray-90 body-1">계정 탈퇴</Text>
               <Icons.ChevronRightIcon color={colors.gray[70]} />
             </TouchableOpacity>
           </View>
@@ -113,7 +107,7 @@ export default function Setting() {
               )
             }
           >
-            <Text className="title-1 text-gray-80">문의하기</Text>
+            <Text className="title-2 text-gray-80">문의하기</Text>
           </TouchableOpacity>
         </View>
 
@@ -124,7 +118,7 @@ export default function Setting() {
               Linking.openURL("https://github.com/Epilogue-1/kokkok")
             }
           >
-            <Text className="title-1 text-gray-80">
+            <Text className="title-2 text-gray-80">
               우리 앱 깃허브 놀러가기
             </Text>
           </TouchableOpacity>
@@ -253,14 +247,14 @@ function NotificationSetting({ setting }: { setting?: PushSetting | null }) {
   return (
     <View className="gap-5 bg-white px-6 py-[22px]">
       <View className="flex-row items-center justify-between ">
-        <Text className="title-1 text-gray-80">알림 설정</Text>
+        <Text className="title-2 text-gray-80">알림 설정</Text>
         <CustomSwitch value={allSwitch} onPress={handleAllSwitchPress} />
       </View>
       {/* 개별 스위치 리스트 */}
       <View className="gap-5 pl-2">
         {Object.keys(SWITCH_CONFIG).map((type) => (
           <View key={type} className="flex-row items-center justify-between">
-            <Text className="font-pregular text-gray-80 text-[18px]">
+            <Text className=" text-gray-90 body-1">
               {SWITCH_CONFIG[type as SwitchType].title}
             </Text>
             <CustomSwitch

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -31,7 +31,7 @@ interface HeaderProps {
 
 export function Header({ name }: HeaderProps) {
   return (
-    <SafeAreaView edges={["top"]} className="border-gray-10 border-b bg-white">
+    <SafeAreaView edges={["top"]} className="border-gray-20 border-b bg-white">
       <View className="h-14 items-center justify-center">
         <Text className="heading-2">{HEADER_TITLE[name]}</Text>
       </View>
@@ -41,14 +41,14 @@ export function Header({ name }: HeaderProps) {
 
 export function HeaderWithBack({ name }: HeaderProps) {
   return (
-    <SafeAreaView edges={["top"]} className="border-gray-10 border-b bg-white">
+    <SafeAreaView edges={["top"]} className="border-gray-20 border-b bg-white">
       <View className="h-14 items-center justify-center px-4">
         <TouchableOpacity
           onPress={() => router.back()}
           accessibilityLabel="뒤로가기"
           className="absolute left-4"
         >
-          <icons.ChevronLeftIcon width={24} height={24} color="#727272" />
+          <icons.ChevronLeftIcon width={24} height={24} color="#222222" />
         </TouchableOpacity>
         <Text className="heading-2">{HEADER_TITLE[name]}</Text>
       </View>
@@ -84,7 +84,7 @@ export function HeaderWithNotification({ name }: HeaderProps) {
   }
 
   return (
-    <SafeAreaView edges={["top"]} className="border-gray-10 border-b bg-white">
+    <SafeAreaView edges={["top"]} className="border-gray-20 border-b bg-white">
       <View className="h-14 flex-row items-center justify-between px-4">
         {/* 홈의 경우 로고 이미지 사용 */}
         {name === "HOME" ? (
@@ -124,7 +124,7 @@ export function HeaderWithUsername({
   return (
     <SafeAreaView
       edges={isMyPage ? ["top"] : []}
-      className="border-gray-10 border-b bg-white"
+      className="border-gray-20 border-b bg-white"
     >
       <View className="h-14 flex-row items-center gap-6 px-4">
         <TouchableOpacity
@@ -132,7 +132,7 @@ export function HeaderWithUsername({
           accessibilityLabel="뒤로가기"
           className=""
         >
-          <icons.ChevronLeftIcon width={24} height={24} color="#727272" />
+          <icons.ChevronLeftIcon width={24} height={24} color="#222222" />
         </TouchableOpacity>
         <View className="w-[285px] flex-row items-center">
           <Text

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -33,7 +33,7 @@ export function Header({ name }: HeaderProps) {
   return (
     <SafeAreaView edges={["top"]} className="border-gray-20 border-b bg-white">
       <View className="h-14 items-center justify-center">
-        <Text className="heading-2">{HEADER_TITLE[name]}</Text>
+        <Text className="title-1">{HEADER_TITLE[name]}</Text>
       </View>
     </SafeAreaView>
   );
@@ -50,7 +50,7 @@ export function HeaderWithBack({ name }: HeaderProps) {
         >
           <icons.ChevronLeftIcon width={24} height={24} color="#222222" />
         </TouchableOpacity>
-        <Text className="heading-2">{HEADER_TITLE[name]}</Text>
+        <Text className="title-1">{HEADER_TITLE[name]}</Text>
       </View>
     </SafeAreaView>
   );
@@ -94,7 +94,7 @@ export function HeaderWithNotification({ name }: HeaderProps) {
             accessibilityLabel="KokKok 로고"
           />
         ) : (
-          <Text className="heading-2">{HEADER_TITLE[name]}</Text>
+          <Text className="title-1">{HEADER_TITLE[name]}</Text>
         )}
 
         <View className="flex-row gap-4">

--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -23,7 +23,7 @@ export function NotificationItem({
     <TouchableWithoutFeedback
       onPress={() => data?.postId && router.push(`/post/${data?.postId}`)}
     >
-      <View className="w-full py-4 border-b border-gray-25 flex-row justify-between items-center">
+      <View className="w-full py-4 border-b border-gray-10 flex-row justify-between items-center">
         <View className="flex-row gap-4">
           <Image
             source={
@@ -41,14 +41,14 @@ export function NotificationItem({
                 {message.content}
               </Text>
             ) : (
-              <Text className="body-5 text-gray-45" numberOfLines={1}>
+              <Text className="body-5 text-gray-60" numberOfLines={1}>
                 {message.content}
               </Text>
             )}
           </View>
         </View>
 
-        <Text className="caption-3 font-pmedium text-gray-50">{diff}</Text>
+        <Text className="caption-2 text-gray-60">{diff}</Text>
       </View>
     </TouchableWithoutFeedback>
   );


### PR DESCRIPTION
## 📝 PR 설명
알림 • 계정 설정 페이지, 하단 탭바 디자인 수정

## 🔍 변경사항
- 알림 • 계정 설정 페이지 : 너비 확장, 폰트 사이즈 및 색상 변경을 변경했습니다.
- 헤더, 하단 탭바 : 헤더의 폰트 사이즈를 축소하고 하단 탭바의 border를 제거했습니다.

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/0f8e3377-ca65-49b1-81bc-a5cb0a2645c9" width="200">
<img src="https://github.com/user-attachments/assets/2dae6ef5-0a79-4bb7-ae09-a9cb7be2b555" width="200">

<br>
<img src="https://github.com/user-attachments/assets/40cc3973-8ff6-4f0c-8283-d4cb99dcafe4" width="200">
<img src="https://github.com/user-attachments/assets/9787aa46-8504-451c-9966-f1b3f20130af" width="200">



## 📌 기타 참고사항
💪

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **스타일**
	- 탭 바의 상단 경계가 제거되어 보다 깔끔한 디자인이 적용되었습니다.
	- 알림 목록의 좌우 패딩이 소폭 축소되어 레이아웃이 최적화되었습니다.
	- 설정 페이지의 배경 색상, 텍스트 스타일 및 크기가 조정되어 가독성이 향상되었습니다.
	- 헤더 영역의 테두리 색상, 타이틀 스타일, 아이콘 색상이 업데이트되었습니다.
	- 알림 항목의 테두리 및 텍스트 색상이 변경되어 UI가 정돈되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->