### PR TITLE
chore: 빌드&제출 명령어 추가 및 자동 릴리즈 생성 action 추가

### DIFF
--- a/.github/workflows/release-on-main-pr.yml
+++ b/.github/workflows/release-on-main-pr.yml
@@ -1,0 +1,73 @@
+name: Release on Main PR Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install GitHub CLI
+        run: sudo apt-get update && sudo apt-get install -y gh jq
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          VERSION=$(jq -r .version package.json)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag already exists
+        id: tag-check
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/v${VERSION}"; then
+            echo "Tag v${VERSION} already exists. Skipping release."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag v${VERSION} does not exist. Proceeding."
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get latest merged PR info
+        id: pr
+        if: steps.tag-check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_INFO=$(gh pr list --state merged --base main --limit 10 --json number,mergedAt | jq 'sort_by(.mergedAt) | reverse | .[0]')
+          PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number')
+          
+          PR_DATA=$(gh pr view "$PR_NUMBER" --json title,body,commits)
+          
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title // "No title"')
+          PR_BODY=$(echo "$PR_DATA" | jq -r '.body // "No description"')
+          PR_COMMITS=$(echo "$PR_DATA" | jq -r '.commits | map("- " + .messageHeadline) | join("\n")')
+          
+          echo "RELEASE_TITLE=$PR_TITLE" >> $GITHUB_ENV
+          echo -e "$PR_BODY\n\n### Commits:\n$PR_COMMITS" > release_body.txt
+
+      - name: Create Git tag
+        if: steps.tag-check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag v${VERSION}
+          git push origin v${VERSION}
+
+      - name: Create GitHub Release
+        if: steps.tag-check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ env.VERSION }}
+          name: ${{ env.RELEASE_TITLE }}
+          body_path: release_body.txt

--- a/app.config.js
+++ b/app.config.js
@@ -21,6 +21,7 @@ module.exports = {
         NSCameraUsageDescription:
           "프로필 사진 촬영과 게시물에 새로운 사진을 추가하기 위해 카메라 접근 권한이 필요합니다.",
         UIViewControllerBasedStatusBarAppearance: true,
+        ITSAppUsesNonExemptEncryption: false,
       },
     },
     android: {

--- a/app.config.js
+++ b/app.config.js
@@ -3,7 +3,7 @@ module.exports = {
     name: "kokkok",
     slug: "kokkok",
     scheme: "kokkok",
-    version: "1.0.0",
+    version: "1.2.0",
     orientation: "portrait",
     icon: "./assets/icon.png",
     userInterfaceStyle: "light",

--- a/eas.json
+++ b/eas.json
@@ -18,7 +18,13 @@
     },
     "production": {
       "autoIncrement": true,
-      "environment": "production"
+      "environment": "production",
+      "android": {
+        "image": "sdk-52"
+      },
+      "ios": {
+        "image": "sdk-52"
+      }
     }
   },
   "submit": {

--- a/eas.json
+++ b/eas.json
@@ -11,10 +11,11 @@
       "environment": "development"
     },
     "preview": {
+      "autoIncrement": true,
+      "environment": "preview",
       "android": {
         "buildType": "apk"
-      },
-      "environment": "preview"
+      }
     },
     "production": {
       "autoIncrement": true,

--- a/eas.json
+++ b/eas.json
@@ -22,6 +22,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascAppId": "6739578519"
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "build:ios": "eas build --platform ios --profile production --non-interactive",
-    "build:android": "eas build --platform android --profile production",
-    "submit:ios": "eas submit --platform ios --latest"
+    "test:ios": "eas build --platform ios --profile production --non-interactive --auto-submit",
+    "test:android": "eas build --platform android --profile preview"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.23.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "build:ios": "eas build --platform ios --profile production --non-interactive",
+    "build:android": "eas build --platform android --profile production",
+    "submit:ios": "eas submit --platform ios --latest"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.23.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokkok",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## 📝 PR 설명

빌드, 제출할 때 명령어 쳐야하는거 번거로워서 좀 더 간편하게 할 수 있도록 세팅했어요.
앞으로는 아래처럼 가능합니다.

### 테스트를 위해 빌드하려면

**1. cli 명령어**

cli로도 빌드할 수 있고요.
명령어 치는거 번거로워서 스크립트 넣었어요.

```bash
npm run test:ios
npm run test:android
```

참고로 명령어는 이런 의미입니다.
- `test:ios` => ios는 production 프로필로 빌드 및 자동 제출 (TestFlight로 테스트)
- `test:android` => android는 preview 프로필로 빌드 (apk 파일로 테스트, preview인 이유는 aab 말고 apk로 만들려고..)

아 그리고 test:ios 할 때 혹시 애플 로그인 요구하는지 궁금한데요.
애플 로그인 없이도 eas submit 가능하게 하고 싶어서 여러가지 테스트해봤는데, 전 이미 애플 로그인을 한 적이 있어서 확신이 안 들더라구요.
혹시 ios 제출 테스트하신다면, **에필로그 애플 계정으로 로그인 안하고** test:ios 혹은 eas submit 가능한지 알려주시면 감사하겠습니다.

**2. expo 버튼 딸각**

expo에 레포지토리 연결해서 버튼 딸각해서 배포 및 제출 가능해요.

<img width="1328" height="851" alt="image" src="https://github.com/user-attachments/assets/6fb04fb5-1059-4108-bf41-b2edb473a88a" />

사진에 보이듯이 `Build From Github` 버튼 누르면 모달창 뜨는데요.
요걸로 특정 브랜치에서 빌드는 물론 자동제출까지 됩니다.

<img width="1197" height="297" alt="image" src="https://github.com/user-attachments/assets/d8c02fe8-020c-4eff-8a27-7ebe787a9298" />

Git ref에 브랜치도 떠서 파악하기 갱장히 편해요.

이거 제가 연결해놓긴 했는데 다른 분들도 가능한지 확인 한번만 부탁드려요.

### 새로운 버전 배포하려면

기존엔 배포할 때 직접 cli 명령어 쳐서 빌드하고 제출했었는데요.
이제 main에 PR merge 되면 자동으로 ios는 빌드&제출하고 android는 빌드하도록 했습니다.
그리고 태그랑 릴리즈도 자동 생성되게 했어요.

**흐름**
1. `dev` 브랜치에서 `vn.n.n` 버전에 대한 PR 작성
2. 해당 버전에 문제가 없다면 `main` 에 PR merge 
3. 해당 버전의 태그 & 릴리즈 자동 생성
4. 해당 버전의 ios 빌드 및 제출 & android 빌드
5. App Store Connect에서 ios 배포 & Expo에서 aab 파일 다운로드하여 Google Play Console에서 Android 배포

**태그**
태그 이름은 `vn.n.n` 형식으로 만들어지고, 버전은 PR 코드의 `package.json`의 `version` 에서 가져옵니다.

(예시)
<img width="1175" height="528" alt="image" src="https://github.com/user-attachments/assets/c09fca46-3b39-429d-9101-81928cded7c4" />

**릴리즈**
릴리즈 제목은 PR 제목으로, 릴리즈 내용은 PR 내용 + 커밋 내역이 들어갑니다.

(예시)
PR을 이렇게 작성했다면,
<img width="700" alt="image" src="https://github.com/user-attachments/assets/5625e77e-624e-4ae1-8c48-a60136d15956" />

릴리즈는 이렇게 생성됩니다.
<img width="700" alt="image" src="https://github.com/user-attachments/assets/d63c3fef-f1b8-49af-a488-43bb8873d21d" />

테스트는 해봤으나 실제로 잘 되는지는 해당 PR merge하고 테스트 한번 더 해봐야 알 것 같습니다.

## 🔍 변경사항

### 앱 빌드해서 테스트하고 싶을 때 사용할 스크립트 추가
- `npm run test:ios`, `npm run test:android`
- `test:ios` => ios는 production 프로필로 빌드 및 자동 제출 (TestFlight로 테스트)
- `test:android` => android는 preview 프로필로 빌드 (apk 파일로 테스트)

### `main` 브랜치에 push되면 태그&릴리즈 생성하는 action 추가
- `main` 브랜치에 PR merge 되면 수행됨
- PR의 `package.json` 의 `version`을 따와 `vn.n.n` 형식의 태그 생성
- 만약 이미 동일한 버전이 있다면 해당 액션 수행하지 않음
- PR 제목, 내용, 커밋 내역으로 릴리즈 생성

### 태그 생성 시, 자동 빌드 및 배포 수행
- (expo에서 설정한거라 코드에는 없는 내용입니다)
- Expo의 Project GitHub settings 에서 설정
- v* 패턴의 태그가 생성된다면, ios는 빌드 및 제출 수행 & android는 빌드 수행
<img width="1245" height="314" alt="image" src="https://github.com/user-attachments/assets/c033b445-4cd9-4184-96ca-94969e6f57cf" />

빌드 트리거는 브랜치, 라벨 등 다양하게 가능한데요. (PR에 라벨 붙이면 빌드되는 것도 가능합니다.)
현재 자동 빌드는 새 버전 배포를 위한 것으로, 새 버전을 배포하려면 태그/릴리즈도 무조건 존재해야 하기 때문에 태그를 트리거로 설정했어요.

### (ios) 앱이 암호화를 사용하지 않음을 명시
- ITSAppUsesNonExemptEncryption: false
- false 안해주면 암호화 관련 문서 제출하라고 배포 막힘
- Apple Store Connect에서 암호화 안한다고 다시 설정해줘야 해서 매우 번거로워서 명시함

### (ios) 앱 아이디 명시
- ascAppId
- 어떤 앱을 submit하는지 알려줌

### production 빌드할 때 빌드 이미지 설정
- 빌드 이미지란? 빌드를 수행할 때의 환경 ([참고](https://docs.expo.dev/build-reference/infrastructure/))
- 빌드 이미지를 정해놓으면 빌드할 때 환경이 바뀌지 않기 때문에, 빌드 환경이 바뀌어서 일어나는 오류를 통제할 수 있음
- 우리 앱은 SDK 52이기 때문에 최적화된 "sdk-52" 로 설정

### preview 프로필도 빌드 번호 자동 증가 설정
- 빌드 번호는 `1.2.0 (53)` 이런 식으로 버전 뒤에 붙는 번호
- preview로 빌드할 때도 빌드 파일 구분할 수 있도록 `"autoIncrement": true` 추가

### 버전 업그레이드: 1.0.0 => 1.2.0
기존 버전이 1.0.0 으로 너무 낮기도 하고... 빌드&배포 테스트할 때 알아보기 쉽게 1.2.0으로 버전을 올렸습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 메인 브랜치에 PR이 병합될 때 자동으로 태그 및 릴리스를 생성하는 GitHub Actions 워크플로우가 추가되었습니다.
  * iOS 앱에 암호화 미사용(ITSAppUsesNonExemptEncryption=false) 설정이 추가되었습니다.

* **설정 변경**
  * 앱 버전이 1.0.0에서 1.2.0으로 업데이트되었습니다.
  * 빌드 및 제출 프로필(eas.json)이 개선되어 자동 버전 증가 및 환경 설정이 명확해졌습니다.
  * iOS/Android용 EAS 빌드를 위한 npm 스크립트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->