### PR TITLE
chore: EAS에서 안드로이드 빌드할 수 있도록 수정

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -28,7 +28,8 @@ module.exports = {
       adaptiveIcon: {
         foregroundImage: "./assets/adaptive-icon.png",
       },
-      googleServicesFile: "./google-services.json",
+      googleServicesFile:
+        process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
       package: "com.epilogue.kokkok",
     },
     web: {


### PR DESCRIPTION
## 📝 PR 설명

원래는 `google-services.json` 파일이 있는 local 환경에서만 안드로이드 빌드가 됐는데요.
Expo에서도 빌드 가능하도록 했어요.
이전에 태그로 자동빌드했을 때 안드로이드만 실패한 것도 이 PR 적용되면 잘 될거에요.

## 🔍 변경사항

- (Expo)  `google-services.json` 파일을 [환경변수](https://expo.dev/accounts/epilogue-1/projects/kokkok/environment-variables) `GOOGLE_SERVICES_JSON`로 추가
-  `app.config.js` 에 환경변수 사용 반영

## 📌 기타 참고사항

Expo에 Google service account key 추가했어요.
이제 안드로이드 auto submit도 가능합니다.
그래서 릴리즈 생성할 때 안드로이드도 ios처럼 자동 빌드는 물론 제출까지 하도록 했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Android 플랫폼의 Google 서비스 파일 경로가 환경 변수(`GOOGLE_SERVICES_JSON`)를 우선적으로 사용하도록 변경되었습니다. 환경 변수가 설정되지 않은 경우 기존 경로(`./google-services.json`)가 사용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->